### PR TITLE
Add powersaving mode to ScanSettings for JB scanner. 

### DIFF
--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerCompat.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerCompat.java
@@ -245,7 +245,7 @@ public abstract class BluetoothLeScannerCompat {
 		}
 
 		/* package */ void handleScanResult(final ScanResult scanResult) {
-			if (mFilters != null && !matches(scanResult))
+			if (mFilters != null && !mFilters.isEmpty() && !matches(scanResult))
 				return;
 
 			final String deviceAddress = scanResult.getDevice().getAddress();


### PR DESCRIPTION
This takes a duration to scan for and then a duration to sleep for until it starts scanning again. It has no effect on Lollipop or higher scanners.

This makes a lot of sense to me for pre-Lollipop as it emulates how lollipop scanning behaves to a certain extent. See this discussion for the background: https://altbeacon.github.io/android-beacon-library/battery_manager.html