### PR TITLE
Bugfix: empty or no filter should match all scan results?

### DIFF
--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerCompat.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerCompat.java
@@ -245,7 +245,7 @@ public abstract class BluetoothLeScannerCompat {
 		}
 
 		/* package */ void handleScanResult(final ScanResult scanResult) {
-			if (mFilters != null && !matches(scanResult))
+			if (mFilters != null && !mFilters.isEmpty() && !matches(scanResult))
 				return;
 
 			final String deviceAddress = scanResult.getDevice().getAddress();


### PR DESCRIPTION
I'm not 100% sure about this but my understanding is that no filter or an empty one should case all scan results to get passed onto the callback.