### PR TITLE
Removed dependency on entire support library

### DIFF
--- a/scanner/build.gradle
+++ b/scanner/build.gradle
@@ -59,7 +59,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:support-v4:23.3.0'
+    compile 'com.android.support:support-annotations:23.3.0'
 }
 
 // The following script creates a POM file required to publish on Maven Central

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScanRecord.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScanRecord.java
@@ -24,12 +24,12 @@ package no.nordicsemi.android.support.v18.scanner;
 
 import android.os.ParcelUuid;
 import android.support.annotation.Nullable;
-import android.support.v4.util.ArrayMap;
 import android.util.Log;
 import android.util.SparseArray;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -185,7 +185,7 @@ public class ScanRecord {
 		int txPowerLevel = Integer.MIN_VALUE;
 
 		SparseArray<byte[]> manufacturerData = new SparseArray<>();
-		Map<ParcelUuid, byte[]> serviceData = new ArrayMap<>();
+		Map<ParcelUuid, byte[]> serviceData = new HashMap<>();
 
 		try {
 			while (currentPos < scanRecord.length) {


### PR DESCRIPTION
Pulling in the entire support library adds a dependency of about 9k methods to an app. Internally, only the annotations are really used, so I've just included that library. Dependency drops to a few hundred methods.