### PR TITLE
Falling back opportunistic scan to low power

### DIFF
--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplLollipop.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplLollipop.java
@@ -183,7 +183,13 @@ import java.util.Map;
 		if (exactCopy || adapter.isOffloadedScanBatchingSupported() && settings.getUseHardwareBatchingIfSupported())
 			builder.setReportDelay(settings.getReportDelayMillis());
 
-		builder.setScanMode(settings.getScanMode());
+		if (settings.getScanMode() != ScanSettings.SCAN_MODE_OPPORTUNISTIC) {
+			builder.setScanMode(settings.getScanMode());
+		} else {
+			// SCAN MORE OPPORTUNISTIC is not supported on Lollipop.
+			// Instead, SCAN_MODE_LOW_POWER will be used.
+			builder.setScanMode(ScanSettings.SCAN_MODE_LOW_POWER);
+		}
 
 		settings.disableUseHardwareCallbackTypes(); // callback types other then CALLBACK_TYPE_ALL_MATCHES are not supported on Lollipop
 


### PR DESCRIPTION
Opportunistic scan is supported on Android Marshmallow onward. 
The current version actually crashed on Lollipop with `SCAN_MODE_OPPORTUNISTIC` value set, as such value was not possible in the native settings.
This PR resolves #42 by implementing a fallback from `SCAN_MODE_OPPORTUNISTIC` to `SCAN_MODE_LOW_POWER` on Lollipop.
Older OS will use intervals set by `Builder#setPowerSave(long, long)` instead.

This PR also sets the default power save values based on the current mode if they were not set explicitly.