### PR TITLE
Migration to Android X (Jetpack)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ The compat library may be found on jcenter repository. Add it to your project by
 following dependency:
 
 ```Groovy
-implementation 'no.nordicsemi.android.support.v18:scanner:1.3.1'
+implementation 'no.nordicsemi.android.support.v18:scanner:1.4.0'
 ```
+
+Projects not migrated to Android Jetpack should use version 1.3.1, which is feature-equal to 1.4.0.
 
 ## API
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,5 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.enableJetifier=true
+android.useAndroidX=true

--- a/scanner/build.gradle
+++ b/scanner/build.gradle
@@ -48,7 +48,7 @@ android {
         versionCode 8
         versionName "1.3.1"
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -62,10 +62,10 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:support-annotations:28.0.0'
+    implementation 'androidx.annotation:annotation:1.1.0-alpha01'
 
-    androidTestImplementation "com.android.support.test:runner:1.0.2"
-    androidTestImplementation "com.android.support.test:rules:1.0.2"
+    androidTestImplementation 'androidx.test:runner:1.1.2-alpha01'
+    androidTestImplementation 'androidx.test:rules:1.1.2-alpha01'
     androidTestImplementation "org.hamcrest:hamcrest-library:1.3"
     androidTestImplementation ("junit:junit:4.12") {
       exclude module: 'hamcrest-core'

--- a/scanner/build.gradle
+++ b/scanner/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'com.jfrog.bintray'
 ext {
     PUBLISH_GROUP_ID = 'no.nordicsemi.android.support.v18'
     PUBLISH_ARTIFACT_ID = 'scanner'
-    PUBLISH_VERSION = '1.3.1'
+    PUBLISH_VERSION = '1.4.0'
 
     bintrayRepo = 'android'
     bintrayName = 'no.nordicsemi.android.support.v18:scanner'
@@ -45,8 +45,8 @@ android {
     defaultConfig {
         minSdkVersion 18
         targetSdkVersion 28
-        versionCode 8
-        versionName "1.3.1"
+        versionCode 20
+        versionName "1.4.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/scanner/src/androidTest/java/no/nordicsemi/android/support/v18/scanner/ScanFilterTest.java
+++ b/scanner/src/androidTest/java/no/nordicsemi/android/support/v18/scanner/ScanFilterTest.java
@@ -20,7 +20,7 @@ import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.os.Parcel;
 import android.os.ParcelUuid;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.runner.AndroidJUnit4;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/scanner/src/androidTest/java/no/nordicsemi/android/support/v18/scanner/ScanRecordTest.java
+++ b/scanner/src/androidTest/java/no/nordicsemi/android/support/v18/scanner/ScanRecordTest.java
@@ -17,7 +17,7 @@
 package no.nordicsemi.android.support.v18.scanner;
 
 import android.os.ParcelUuid;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.runner.AndroidJUnit4;
 import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/scanner/src/androidTest/java/no/nordicsemi/android/support/v18/scanner/ScanResultTest.java
+++ b/scanner/src/androidTest/java/no/nordicsemi/android/support/v18/scanner/ScanResultTest.java
@@ -19,7 +19,7 @@ package no.nordicsemi.android.support.v18.scanner;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.os.Parcel;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.runner.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/scanner/src/androidTest/java/no/nordicsemi/android/support/v18/scanner/ScanSettingsTest.java
+++ b/scanner/src/androidTest/java/no/nordicsemi/android/support/v18/scanner/ScanSettingsTest.java
@@ -16,7 +16,7 @@
 
 package no.nordicsemi.android.support.v18.scanner;
 
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.runner.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerCompat.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerCompat.java
@@ -29,9 +29,9 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.SystemClock;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.RequiresPermission;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresPermission;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplJB.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplJB.java
@@ -31,9 +31,9 @@ import android.content.Intent;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.SystemClock;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.RequiresPermission;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresPermission;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplLollipop.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplLollipop.java
@@ -32,8 +32,8 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.Handler;
 import android.os.SystemClock;
-import android.support.annotation.NonNull;
-import android.support.annotation.RequiresPermission;
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresPermission;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplMarshmallow.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplMarshmallow.java
@@ -25,7 +25,7 @@ package no.nordicsemi.android.support.v18.scanner;
 import android.annotation.TargetApi;
 import android.bluetooth.BluetoothAdapter;
 import android.os.Build;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 @TargetApi(Build.VERSION_CODES.M)
 /* package */ class BluetoothLeScannerImplMarshmallow extends BluetoothLeScannerImplLollipop {

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplOreo.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplOreo.java
@@ -31,15 +31,14 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Handler;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.RequiresPermission;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresPermission;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @TargetApi(Build.VERSION_CODES.O)
 /* package */ class BluetoothLeScannerImplOreo extends BluetoothLeScannerImplMarshmallow {

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeUtils.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeUtils.java
@@ -18,8 +18,8 @@ package no.nordicsemi.android.support.v18.scanner;
 
 import android.Manifest;
 import android.bluetooth.BluetoothAdapter;
-import android.support.annotation.Nullable;
-import android.support.annotation.RequiresPermission;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresPermission;
 import android.util.SparseArray;
 
 import java.util.Arrays;

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/PendingIntentExecutor.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/PendingIntentExecutor.java
@@ -6,8 +6,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Parcelable;
 import android.os.SystemClock;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/PendingIntentReceiver.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/PendingIntentReceiver.java
@@ -7,7 +7,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
-import android.support.annotation.RequiresApi;
+import androidx.annotation.RequiresApi;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScanCallback.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScanCallback.java
@@ -22,7 +22,7 @@
 
 package no.nordicsemi.android.support.v18.scanner;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.util.List;
 

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScanFilter.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScanFilter.java
@@ -27,8 +27,8 @@ import android.bluetooth.BluetoothDevice;
 import android.os.Parcel;
 import android.os.ParcelUuid;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.List;

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScanRecord.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScanRecord.java
@@ -24,8 +24,8 @@
 package no.nordicsemi.android.support.v18.scanner;
 
 import android.os.ParcelUuid;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.Log;
 import android.util.SparseArray;
 

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScanResult.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScanResult.java
@@ -25,8 +25,8 @@ package no.nordicsemi.android.support.v18.scanner;
 import android.bluetooth.BluetoothDevice;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**7
  * ScanResult for Bluetooth LE scan.

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScanSettings.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScanSettings.java
@@ -25,7 +25,7 @@ package no.nordicsemi.android.support.v18.scanner;
 import android.bluetooth.BluetoothDevice;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.util.List;
 

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScannerService.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScannerService.java
@@ -7,9 +7,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Handler;
 import android.os.IBinder;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.RequiresPermission;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresPermission;
 import android.util.Log;
 
 import java.util.ArrayList;


### PR DESCRIPTION
The library is feature-equal to version 1.3.1, just migrated to AndroidX dependencies.
Projects not migrated should use version 1.3.1. As old support libraries has been deprecated, all future updates will be done only to the migrated version.