### PR TITLE
Allow override of Build.VERSION.SDK_INT (could help with compatibility)

### DIFF
--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerCompat.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerCompat.java
@@ -26,7 +26,6 @@ import android.Manifest;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.os.Build;
-import android.os.Build.VERSION;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.SystemClock;
@@ -90,7 +89,7 @@ public abstract class BluetoothLeScannerCompat {
 
 	private static BluetoothLeScannerCompat instance;
 
-	private static int versionSdkInt = VERSION.SDK_INT;
+	private static int versionSdkInt = Build.VERSION.SDK_INT;
 
 	public static void setScannerApi(int versionSdkInt) {
         BluetoothLeScannerCompat.versionSdkInt = versionSdkInt;

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerCompat.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerCompat.java
@@ -26,6 +26,7 @@ import android.Manifest;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.os.Build;
+import android.os.Build.VERSION;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.SystemClock;
@@ -89,7 +90,7 @@ public abstract class BluetoothLeScannerCompat {
 
 	private static BluetoothLeScannerCompat instance;
 
-	private static int versionSdkInt;
+	private static int versionSdkInt = VERSION.SDK_INT;
 
 	public static void setScannerApi(int versionSdkInt) {
         BluetoothLeScannerCompat.versionSdkInt = versionSdkInt;

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerCompat.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerCompat.java
@@ -89,6 +89,12 @@ public abstract class BluetoothLeScannerCompat {
 
 	private static BluetoothLeScannerCompat instance;
 
+	private static int versionSdkInt;
+
+	public static void setScannerApi(int versionSdkInt) {
+        BluetoothLeScannerCompat.versionSdkInt = versionSdkInt;
+    }
+
 	/**
 	 * Returns the scanner compat object
 	 * @return scanner implementation
@@ -97,11 +103,11 @@ public abstract class BluetoothLeScannerCompat {
 	public synchronized static BluetoothLeScannerCompat getScanner() {
 		if (instance != null)
 			return instance;
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+		if (versionSdkInt >= Build.VERSION_CODES.O)
 			return instance = new BluetoothLeScannerImplOreo();
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+		if (versionSdkInt >= Build.VERSION_CODES.M)
 			return instance = new BluetoothLeScannerImplMarshmallow();
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+		if (versionSdkInt >= Build.VERSION_CODES.LOLLIPOP)
 			return instance = new BluetoothLeScannerImplLollipop();
 		return instance = new BluetoothLeScannerImplJB();
 	}

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScannerService.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScannerService.java
@@ -53,33 +53,38 @@ public class ScannerService extends Service {
     @Override
     @RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
     public int onStartCommand(final Intent intent, final int flags, final int startId) {
-        final PendingIntent callbackIntent = intent.getParcelableExtra(EXTRA_PENDING_INTENT);
-        final boolean start = intent.getBooleanExtra(EXTRA_START, false);
-        final boolean stop = !start;
+        //
+        // null intent observed on Samsung Galaxy J7 Android 6.0.1
+        //
+        if (intent != null) {
+            final PendingIntent callbackIntent = intent.getParcelableExtra(EXTRA_PENDING_INTENT);
+            final boolean start = intent.getBooleanExtra(EXTRA_START, false);
+            final boolean stop = !start;
 
-        if (callbackIntent == null) {
-            boolean shouldStop;
-            synchronized (LOCK) {
-                shouldStop = callbacks.isEmpty();
+            if (callbackIntent == null) {
+                boolean shouldStop;
+                synchronized (LOCK) {
+                    shouldStop = callbacks.isEmpty();
+                }
+                if (shouldStop)
+                    stopSelf();
+                return START_NOT_STICKY;
             }
-            if (shouldStop)
-                stopSelf();
-            return START_NOT_STICKY;
-        }
 
-        boolean knownCallback;
-        synchronized (LOCK) {
-            knownCallback = callbacks.containsKey(callbackIntent);
-        }
+            boolean knownCallback;
+            synchronized (LOCK) {
+                knownCallback = callbacks.containsKey(callbackIntent);
+            }
 
-        if (start && !knownCallback) {
-            final ArrayList<ScanFilter> filters = intent.getParcelableArrayListExtra(EXTRA_FILTERS);
-            final ScanSettings settings = intent.getParcelableExtra(EXTRA_SETTINGS);
-            startScan(filters != null ? filters : Collections.<ScanFilter>emptyList(),
-                    settings != null ? settings : new ScanSettings.Builder().build(),
-                    callbackIntent);
-        } else if (stop && knownCallback) {
-            stopScan(callbackIntent);
+            if (start && !knownCallback) {
+                final ArrayList<ScanFilter> filters = intent.getParcelableArrayListExtra(EXTRA_FILTERS);
+                final ScanSettings settings = intent.getParcelableExtra(EXTRA_SETTINGS);
+                startScan(filters != null ? filters : Collections.<ScanFilter>emptyList(),
+                        settings != null ? settings : new ScanSettings.Builder().build(),
+                        callbackIntent);
+            } else if (stop && knownCallback) {
+                stopScan(callbackIntent);
+            }
         }
 
         return START_NOT_STICKY;


### PR DESCRIPTION
Before I found this [Android-Scanner-Compat-Library] library, I had rolled my own and allowed my code to set the version of the scanner it wanted to use.
We could ask a user to change the version to something else, and sometimes that fixed things.
Perhaps y'all would think this change is helpful too.