### PR TITLE
Handling null intent observed on Samsung Galaxy J7 Android 6.0.1

### DIFF
--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScannerService.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScannerService.java
@@ -53,33 +53,38 @@ public class ScannerService extends Service {
     @Override
     @RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
     public int onStartCommand(final Intent intent, final int flags, final int startId) {
-        final PendingIntent callbackIntent = intent.getParcelableExtra(EXTRA_PENDING_INTENT);
-        final boolean start = intent.getBooleanExtra(EXTRA_START, false);
-        final boolean stop = !start;
+        //
+        // null intent observed on Samsung Galaxy J7 Android 6.0.1
+        //
+        if (intent != null) {
+            final PendingIntent callbackIntent = intent.getParcelableExtra(EXTRA_PENDING_INTENT);
+            final boolean start = intent.getBooleanExtra(EXTRA_START, false);
+            final boolean stop = !start;
 
-        if (callbackIntent == null) {
-            boolean shouldStop;
-            synchronized (LOCK) {
-                shouldStop = callbacks.isEmpty();
+            if (callbackIntent == null) {
+                boolean shouldStop;
+                synchronized (LOCK) {
+                    shouldStop = callbacks.isEmpty();
+                }
+                if (shouldStop)
+                    stopSelf();
+                return START_NOT_STICKY;
             }
-            if (shouldStop)
-                stopSelf();
-            return START_NOT_STICKY;
-        }
 
-        boolean knownCallback;
-        synchronized (LOCK) {
-            knownCallback = callbacks.containsKey(callbackIntent);
-        }
+            boolean knownCallback;
+            synchronized (LOCK) {
+                knownCallback = callbacks.containsKey(callbackIntent);
+            }
 
-        if (start && !knownCallback) {
-            final ArrayList<ScanFilter> filters = intent.getParcelableArrayListExtra(EXTRA_FILTERS);
-            final ScanSettings settings = intent.getParcelableExtra(EXTRA_SETTINGS);
-            startScan(filters != null ? filters : Collections.<ScanFilter>emptyList(),
-                    settings != null ? settings : new ScanSettings.Builder().build(),
-                    callbackIntent);
-        } else if (stop && knownCallback) {
-            stopScan(callbackIntent);
+            if (start && !knownCallback) {
+                final ArrayList<ScanFilter> filters = intent.getParcelableArrayListExtra(EXTRA_FILTERS);
+                final ScanSettings settings = intent.getParcelableExtra(EXTRA_SETTINGS);
+                startScan(filters != null ? filters : Collections.<ScanFilter>emptyList(),
+                        settings != null ? settings : new ScanSettings.Builder().build(),
+                        callbackIntent);
+            } else if (stop && knownCallback) {
+                stopScan(callbackIntent);
+            }
         }
 
         return START_NOT_STICKY;


### PR DESCRIPTION
I have seen the following crash in production:
```
Fatal Exception: java.lang.RuntimeException
Unable to start service no.nordicsemi.android.support.v18.scanner.ScannerService@b5cac51 with null: java.lang.NullPointerException: Attempt to invoke virtual method 'android.os.Parcelable android.content.Intent.getParcelableExtra(java.lang.String)' on a null object reference
android.app.ActivityThread.handleServiceArgs (ActivityThread.java:4145)
android.app.ActivityThread.access$2400 (ActivityThread.java:229)
android.app.ActivityThread$H.handleMessage (ActivityThread.java:1924)
android.os.Handler.dispatchMessage (Handler.java:102)
android.os.Looper.loop (Looper.java:148)
android.app.ActivityThread.main (ActivityThread.java:7325)
java.lang.reflect.Method.invoke (Method.java)
com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run (ZygoteInit.java:1230)
com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1120)
Caused by java.lang.NullPointerException
Attempt to invoke virtual method 'android.os.Parcelable android.content.Intent.getParcelableExtra(java.lang.String)' on a null object reference
no.nordicsemi.android.support.v18.scanner.ScannerService.onStartCommand (ScannerService.java:56)
...
```

I don't know why intent == null, but looking at the code...
https://github.com/NordicSemiconductor/Android-Scanner-Compat-Library/blob/master/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScannerService.java#L56
...ScannerService.onStartCommand indeed cannot handle a null intent.

This is an attempt to work around this issue.
I don't know if still returning START_NOT_STICKY if intent == null is appropriate.