### PR TITLE
Fixing scanning "leak" that DoSed all scanning after ~>32 scans

### DIFF
--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplOreo.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplOreo.java
@@ -192,7 +192,7 @@ import java.util.List;
 		final Intent intent = new Intent(context, PendingIntentReceiver.class);
 		intent.setAction(PendingIntentReceiver.ACTION);
 
-		return PendingIntent.getBroadcast(context, id, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+		return PendingIntent.getBroadcast(context, id, intent, PendingIntent.FLAG_UPDATE_CURRENT);
 	}
 
 	@NonNull


### PR DESCRIPTION
Fix for #58 

I am not certain if changing the flag will have any undesirable side-effects on the rest of the code.