### PR TITLE
Migration to Java 8

### DIFF
--- a/scanner/build.gradle
+++ b/scanner/build.gradle
@@ -19,10 +19,6 @@ android {
             testCoverageEnabled true
         }
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
-    }
 }
 
 dependencies {

--- a/scanner/build.gradle
+++ b/scanner/build.gradle
@@ -19,6 +19,10 @@ android {
             testCoverageEnabled true
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplJB.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplJB.java
@@ -25,7 +25,6 @@ package no.nordicsemi.android.support.v18.scanner;
 import android.Manifest;
 import android.app.PendingIntent;
 import android.bluetooth.BluetoothAdapter;
-import android.bluetooth.BluetoothDevice;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Handler;
@@ -234,22 +233,14 @@ import androidx.annotation.RequiresPermission;
 		}
 	}
 
-	private final BluetoothAdapter.LeScanCallback scanCallback = new BluetoothAdapter.LeScanCallback() {
-		@Override
-		public void onLeScan(final BluetoothDevice device, final int rssi, final byte[] scanRecord) {
-			final ScanResult scanResult = new ScanResult(device, ScanRecord.parseFromBytes(scanRecord),
-					rssi, SystemClock.elapsedRealtimeNanos());
+	private final BluetoothAdapter.LeScanCallback scanCallback = (device, rssi, scanRecord) -> {
+		final ScanResult scanResult = new ScanResult(device, ScanRecord.parseFromBytes(scanRecord),
+				rssi, SystemClock.elapsedRealtimeNanos());
 
-			synchronized (wrappers) {
-				final Collection<ScanCallbackWrapper> scanCallbackWrappers = wrappers.values();
-				for (final ScanCallbackWrapper wrapper : scanCallbackWrappers) {
-					wrapper.handler.post(new Runnable() {
-						@Override
-						public void run() {
-							wrapper.handleScanResult(ScanSettings.CALLBACK_TYPE_ALL_MATCHES, scanResult);
-						}
-					});
-				}
+		synchronized (wrappers) {
+			final Collection<ScanCallbackWrapper> scanCallbackWrappers = wrappers.values();
+			for (final ScanCallbackWrapper wrapper : scanCallbackWrappers) {
+				wrapper.handler.post(() -> wrapper.handleScanResult(ScanSettings.CALLBACK_TYPE_ALL_MATCHES, scanResult));
 			}
 		}
 	};

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplOreo.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplOreo.java
@@ -95,7 +95,7 @@ import androidx.annotation.RequiresPermission;
 			throw new IllegalStateException("BT le scanner not available");
 
 		final ScanSettings nonNullSettings = settings != null ? settings : new ScanSettings.Builder().build();
-		final List<ScanFilter> nonNullFilters = filters != null ? filters : Collections.<ScanFilter>emptyList();
+		final List<ScanFilter> nonNullFilters = filters != null ? filters : Collections.emptyList();
 
 		final android.bluetooth.le.ScanSettings nativeSettings = toNativeScanSettings(adapter, nonNullSettings, false);
 		List<android.bluetooth.le.ScanFilter> nativeFilters = null;

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeUtils.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeUtils.java
@@ -67,6 +67,7 @@ class BluetoothLeUtils {
 		while (it.hasNext()) {
 			final Map.Entry<T, byte[]> entry = it.next();
 			final Object key = entry.getKey();
+			//noinspection SuspiciousMethodCalls
 			buffer.append(key).append("=").append(Arrays.toString(map.get(key)));
 			if (it.hasNext()) {
 				buffer.append(", ");

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/PendingIntentExecutor.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/PendingIntentExecutor.java
@@ -27,7 +27,7 @@ import androidx.annotation.Nullable;
 	@Nullable private Context service;
 
     private long lastBatchTimestamp;
-    private long reportDelay;
+    private final long reportDelay;
 
     /**
      * Creates the {@link PendingIntent} executor that will be used from a

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScanResult.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScanResult.java
@@ -79,26 +79,25 @@ public final class ScanResult implements Parcelable {
 	static final int ET_CONNECTABLE_MASK = 0x01;
 
 	// Remote Bluetooth device.
-	@SuppressWarnings("NullableProblems")
 	@NonNull
-	private BluetoothDevice device;
+	private final BluetoothDevice device;
 
 	// Scan record, including advertising data and scan response data.
 	@Nullable
 	private ScanRecord scanRecord;
 
 	// Received signal strength.
-	private int rssi;
+	private final int rssi;
 
 	// Device timestamp when the result was last seen.
-	private long timestampNanos;
+	private final long timestampNanos;
 
-	private int eventType;
-	private int primaryPhy;
-	private int secondaryPhy;
-	private int advertisingSid;
-	private int txPower;
-	private int periodicAdvertisingInterval;
+	private final int eventType;
+	private final int primaryPhy;
+	private final int secondaryPhy;
+	private final int advertisingSid;
+	private final int txPower;
+	private final int periodicAdvertisingInterval;
 
 	/**
 	 * Constructs a new ScanResult.
@@ -155,7 +154,18 @@ public final class ScanResult implements Parcelable {
 	}
 
 	private ScanResult(final Parcel in) {
-		readFromParcel(in);
+		device = BluetoothDevice.CREATOR.createFromParcel(in);
+		if (in.readInt() == 1) {
+			scanRecord = ScanRecord.parseFromBytes(in.createByteArray());
+		}
+		rssi = in.readInt();
+		timestampNanos = in.readLong();
+		eventType = in.readInt();
+		primaryPhy = in.readInt();
+		secondaryPhy = in.readInt();
+		advertisingSid = in.readInt();
+		txPower = in.readInt();
+		periodicAdvertisingInterval = in.readInt();
 	}
 
 	@Override
@@ -175,21 +185,6 @@ public final class ScanResult implements Parcelable {
 		dest.writeInt(advertisingSid);
 		dest.writeInt(txPower);
 		dest.writeInt(periodicAdvertisingInterval);
-	}
-
-	private void readFromParcel(final Parcel in) {
-		device = BluetoothDevice.CREATOR.createFromParcel(in);
-		if (in.readInt() == 1) {
-			scanRecord = ScanRecord.parseFromBytes(in.createByteArray());
-		}
-		rssi = in.readInt();
-		timestampNanos = in.readLong();
-		eventType = in.readInt();
-		primaryPhy = in.readInt();
-		secondaryPhy = in.readInt();
-		advertisingSid = in.readInt();
-		txPower = in.readInt();
-		periodicAdvertisingInterval = in.readInt();
 	}
 
 	@Override

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScanSettings.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScanSettings.java
@@ -152,32 +152,32 @@ public final class ScanSettings implements Parcelable {
 	private final long powerSaveRestInterval;
 
 	// Bluetooth LE scan mode.
-	private int scanMode;
+	private final int scanMode;
 
 	// Bluetooth LE scan callback type
-	private int callbackType;
+	private final int callbackType;
 
 	// Time of delay for reporting the scan result
-	private long reportDelayMillis;
+	private final long reportDelayMillis;
 
-	private int matchMode;
+	private final int matchMode;
 
-	private int numOfMatchesPerFilter;
+	private final int numOfMatchesPerFilter;
 
-	private boolean useHardwareFilteringIfSupported;
+	private final boolean useHardwareFilteringIfSupported;
 
-	private boolean useHardwareBatchingIfSupported;
+	private final boolean useHardwareBatchingIfSupported;
 
 	private boolean useHardwareCallbackTypesIfSupported;
 
-	private long matchLostDeviceTimeout;
+	private final long matchLostDeviceTimeout;
 
-	private long matchLostTaskInterval;
+	private final long matchLostTaskInterval;
 
 	// Include only legacy advertising results
-	private boolean legacy;
+	private final boolean legacy;
 
-	private int phy;
+	private final int phy;
 
 	public int getScanMode() {
 		return scanMode;
@@ -249,11 +249,13 @@ public final class ScanSettings implements Parcelable {
 	}
 
 	private ScanSettings(final int scanMode, final int callbackType,
-						 final long reportDelayMillis, final int matchMode,
-						 final int numOfMatchesPerFilter, final boolean legacy, final int phy,
-						 final boolean hardwareFiltering, final boolean hardwareBatching,
-						 final boolean hardwareCallbackTypes, final long matchTimeout,
-						 final long taskInterval,
+						 final long reportDelayMillis,
+						 final int matchMode, final int numOfMatchesPerFilter,
+						 final boolean legacy, final int phy,
+						 final boolean hardwareFiltering,
+						 final boolean hardwareBatching,
+						 final boolean hardwareCallbackTypes,
+						 final long matchTimeout, final long taskInterval,
 						 final long powerSaveScanInterval, final long powerSaveRestInterval) {
 		this.scanMode = scanMode;
 		this.callbackType = callbackType;
@@ -281,6 +283,8 @@ public final class ScanSettings implements Parcelable {
 		phy = in.readInt();
 		useHardwareFilteringIfSupported = in.readInt() == 1;
 		useHardwareBatchingIfSupported = in.readInt() == 1;
+		matchLostDeviceTimeout = in.readLong();
+		matchLostTaskInterval = in.readLong();
 		powerSaveScanInterval = in.readLong();
 		powerSaveRestInterval = in.readLong();
 	}
@@ -296,6 +300,8 @@ public final class ScanSettings implements Parcelable {
 		dest.writeInt(phy);
 		dest.writeInt(useHardwareFilteringIfSupported ? 1 : 0);
 		dest.writeInt(useHardwareBatchingIfSupported ? 1 : 0);
+		dest.writeLong(matchLostDeviceTimeout);
+		dest.writeLong(matchLostTaskInterval);
 		dest.writeLong(powerSaveScanInterval);
 		dest.writeLong(powerSaveRestInterval);
 	}

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScannerService.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScannerService.java
@@ -82,7 +82,7 @@ public class ScannerService extends Service {
             if (start && !knownCallback) {
                 final ArrayList<ScanFilter> filters = intent.getParcelableArrayListExtra(EXTRA_FILTERS);
                 final ScanSettings settings = intent.getParcelableExtra(EXTRA_SETTINGS);
-                startScan(filters != null ? filters : Collections.<ScanFilter>emptyList(),
+                startScan(filters != null ? filters : Collections.emptyList(),
                         settings != null ? settings : new ScanSettings.Builder().build(),
                         callbackIntent, requestCode);
             } else if (stop && knownCallback) {


### PR DESCRIPTION
As Java 8 is now many years old, and Android Studio supports actually Java 11, it is time to migrate this project to Java 8.
This allows to clean up the code by remove unnecessary types inference and introducing lambdas.