### PR TITLE
Version 1.4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The compat library may be found on Maven Central repository. Add it to your proj
 following dependency:
 
 ```Groovy
-implementation 'no.nordicsemi.android.support.v18:scanner:1.4.4'
+implementation 'no.nordicsemi.android.support.v18:scanner:1.4.5'
 ```
 
 Projects not migrated to Android Jetpack should use version 1.3.1, which is feature-equal to 1.4.0.
@@ -144,12 +144,12 @@ your application has been killed (the receiver must be added in *AndroidManifest
 
 Starting from version 1.3.0, this library may emulate such feature on older Android versions.
 In order to do that, a background service will be started after calling 
-`scanner.startScan(filters, settings, context, pendingIntent)`, which will be scanning in 
+`scanner.startScan(filters, settings, context, pendingIntent, requestCode)`, which will be scanning in 
 background with given settings and will send the given `PendingIntent` when a device 
 matching filter is found. To lower battery consumption it is recommended to set 
 `ScanSettings.SCAN_MODE_LOW_POWER` scanning mode and use filter, but even with those conditions fulfilled
 **the battery consumption will be significantly higher than on Oreo+**. To stop scanning call 
-`scanner.stopScan(context, pendingIntent)` with 
+`scanner.stopScan(context, pendingIntent, requestCode)` with 
 [the same](https://developer.android.com/reference/android/app/PendingIntent) intent in parameter. 
 The service will be stopped when the last scan was stopped.
 
@@ -167,7 +167,7 @@ To use this feature:
     Intent intent = new Intent(context, MyReceiver.class); // explicite intent 
 	intent.setAction("com.example.ACTION_FOUND");
 	intent.putExtra("some.extra", value); // optional
-	PendingIntent pendingIntent = PendingIntent.getBroadcast(context, id, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+	PendingIntent pendingIntent = PendingIntent.getBroadcast(context, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT);
 	
 	BluetoothLeScannerCompat scanner = BluetoothLeScannerCompat.getScanner();
 	ScanSettings settings = new ScanSettings.Builder()
@@ -176,7 +176,7 @@ To use this feature:
 				.build();
 	List<ScanFilter> filters = new ArrayList<>();
 	filters.add(new ScanFilter.Builder().setServiceUuid(mUuid).build());
-	scanner.startScan(filters, settings, context, pendingIntent);
+	scanner.startScan(filters, settings, context, pendingIntent, requestCode);
 ```
 
 Add your `MyRecever` to *AndroidManifest*, as the application context might have been released 
@@ -185,17 +185,21 @@ and all broadcast receivers registered to it together with it.
 To stop scanning call:
 
 ```java
-	// To stop scanning use the same or an equal PendingIntent (check PendingIntent documentation)
+	// To stop scanning use the same PendingIntent and request code as one used to start scanning.
     Intent intent = new Intent(context, MyReceiver.class);
 	intent.setAction("com.example.ACTION_FOUND");
-	PendingIntent pendingIntent = PendingIntent.getBroadcast(context, id, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+	PendingIntent pendingIntent = PendingIntent.getBroadcast(context, requestCode, intent, PendingIntent.FLAG_CANCEL_CURRENT);
 	
 	BluetoothLeScannerCompat scanner = BluetoothLeScannerCompat.getScanner();
-	scanner.stopScan(context, pendingIntent);
+	scanner.stopScan(context, pendingIntent, requestCode);
 ```
 
 **Note:** Android versions 6 and 7 will not report any advertising packets when in Doze mode.
 Read more about it here: https://developer.android.com/training/monitoring-device-state/doze-standby
+
+**Note 2:** An additional parameter called `requestCode` was added in version 1.4.5 to the above API.
+It is to ensure that the scanning would be correctly stopped. If not provided, a request code equal
+to 0 will be used preventing from having multiple scanning tasks. 
 
 ## Background scanning guidelines
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@
 # org.gradle.parallel=true
 android.useAndroidX=true
 
-VERSION_NAME=1.4.4
+VERSION_NAME=1.4.5
 GROUP=no.nordicsemi.android.support.v18
 
 POM_DESCRIPTION=Android Bluetooth LE Scanner Compat library

--- a/scanner/build.gradle
+++ b/scanner/build.gradle
@@ -19,29 +19,31 @@ android {
             testCoverageEnabled true
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_7
+        targetCompatibility JavaVersion.VERSION_1_7
+    }
 }
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.2.0'
 
-    androidTestImplementation 'androidx.test:runner:1.4.0-beta01'
-    androidTestImplementation 'androidx.test:rules:1.4.0-beta01'
-    androidTestImplementation 'org.hamcrest:hamcrest-library:2.1'
-    androidTestImplementation ('junit:junit:4.13.2') {
-      exclude module: 'hamcrest-core'
-    }
+    // Core library
+    androidTestImplementation 'androidx.test:core:1.3.0'
 
-    testImplementation 'org.hamcrest:hamcrest-library:2.1'
-    testImplementation ('junit:junit:4.13.2') {
-      exclude module: 'hamcrest-core'
-    }
-    testImplementation "org.mockito:mockito-core:2.18.0"
-    testImplementation "org.powermock:powermock-module-junit4:1.7.4"
-    testImplementation "org.powermock:powermock-api-mockito:1.7.4"
+    // AndroidJUnitRunner
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+
+    // Assertions & AndroidJUnit4
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+
+    // Truth for Unit Testing
+    androidTestImplementation "com.google.truth:truth:1.1.3"
+    testImplementation "com.google.truth:truth:1.1.3"
 }
 
 // === Maven Central configuration ===
-// The following file exists only when Android BLE Library project is opened, but not
+// The following file exists only when Android Scanner Compat Library project is opened, but not
 // when the module is loaded to a different project.
 if (rootProject.file('gradle/publish-module.gradle').exists()) {
     ext {

--- a/scanner/src/androidTest/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplOreoTest.java
+++ b/scanner/src/androidTest/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplOreoTest.java
@@ -2,78 +2,74 @@ package no.nordicsemi.android.support.v18.scanner;
 
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
-import android.os.ParcelUuid;
-import android.util.SparseArray;
 
 import org.junit.Test;
 
-import java.lang.reflect.Constructor;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
+import static com.google.common.truth.Truth.assertThat;
 
 public class BluetoothLeScannerImplOreoTest {
 
 	@Test
 	public void toImpl() {
 		// Build mock data
-		List<ParcelUuid> serviceUuids = new ArrayList<>();
-		serviceUuids.add(ParcelUuid.fromString("00001809-0000-1000-8000-00805F9B34FB"));
+		final byte[] bytes = new byte[]{
+				2, 1, 6, 								// Flags
+				5, 8, 'T', 'e', 's', 't',				// Shortened Local Name (Test)
+				6, (byte) 0xFF, 0x59, 0x00, 1, 2, 3,	// Manufacturer Data (Nordic Semi -> 0x010203)
+				3, 0x16, 0x09, 0x18,					// Service Data - 16-bit UUID (0x1809)
+				2, 0x0A, 1								// Tx Power Level (1 dBm)
+		};
 
-		SparseArray<byte[]> manufacturerData = new SparseArray<>();
-		manufacturerData.append(0x0059, new byte[] { 1, 2, 3});
+		final BluetoothDevice device =
+				BluetoothAdapter.getDefaultAdapter().getRemoteDevice("01:02:03:04:05:06");
 
-		Map<ParcelUuid, byte[]> serviceData = new HashMap<>();
-		serviceData.put(ParcelUuid.fromString("00001809-0000-1000-8000-00805F9B34FB"), new byte[] { 0x64 });
+		final android.bluetooth.le.ScanRecord _record = parseScanRecord(bytes);
 
-		final byte[] bytes = new byte[] { 2, 1, 6, 5, 8, 'T', 'e', 's', 't', 6, (byte) 0xFF, 0x59, 0x00, 1, 2, 3, 4, 0x16, 0x09, 0x18, 0x64, 2, 0x0A, 1};
+		android.bluetooth.le.ScanResult _result = new android.bluetooth.le.ScanResult(device,
+				0b000001, 1, 2, 0,
+				android.bluetooth.le.ScanResult.TX_POWER_NOT_PRESENT, -70,
+				android.bluetooth.le.ScanResult.PERIODIC_INTERVAL_NOT_PRESENT, _record,
+				123456789L);
 
+		// Convert to support.v18.ScanResult
+		final BluetoothLeScannerImplOreo impl = new BluetoothLeScannerImplOreo();
+		final ScanResult result = impl.fromNativeScanResult(_result);
+
+		// Validate
+		assertThat(result).isNotNull();
+		assertThat(_record).isNotNull();
+		assertThat(_result.isLegacy()).isEqualTo(result.isLegacy());
+		assertThat(_result.isConnectable()).isEqualTo(result.isConnectable());
+		assertThat(result.getDataStatus()).isEqualTo(ScanResult.DATA_COMPLETE);
+		assertThat(result.getScanRecord()).isNotNull();
+		final ScanRecord record = result.getScanRecord();
+		assertThat(record.getAdvertiseFlags()).isEqualTo(6);
+		assertThat(bytes).isEqualTo(record.getBytes());
+		assertThat(record.getManufacturerSpecificData(0x0059)).isNotNull();
+		assertThat(_record.getManufacturerSpecificData(0x0059))
+				.isEqualTo(record.getManufacturerSpecificData(0x0059));
+		assertThat(result.getPeriodicAdvertisingInterval())
+				.isEqualTo(ScanResult.PERIODIC_INTERVAL_NOT_PRESENT);
+		assertThat(result.getTxPower()).isEqualTo(ScanResult.TX_POWER_NOT_PRESENT);
+		assertThat(result.getTimestampNanos()).isEqualTo(123456789L);
+		assertThat(_result.getDevice()).isEqualTo(result.getDevice());
+		assertThat(device).isEqualTo(result.getDevice());
+	}
+
+	/**
+	 * Utility method to call hidden ScanRecord.parseFromBytes method.
+	 */
+	static android.bluetooth.le.ScanRecord parseScanRecord(byte[] bytes) {
+		final Class<?> scanRecordClass = android.bluetooth.le.ScanRecord.class;
 		try {
-			BluetoothDevice device =
-					BluetoothAdapter.getDefaultAdapter().getRemoteDevice("01:02:03:04:05:06");
-
-			final Constructor constructor =
-					android.bluetooth.le.ScanRecord.class.getDeclaredConstructor(List.class,
-					SparseArray.class, Map.class, int.class, int.class, String.class, byte[].class);
-			constructor.setAccessible(true);
-			final android.bluetooth.le.ScanRecord _record = (android.bluetooth.le.ScanRecord)
-					constructor.newInstance(serviceUuids, manufacturerData, serviceData, 0x06, 1, "Test", bytes);
-
-			android.bluetooth.le.ScanResult _result = new android.bluetooth.le.ScanResult(device,
-					0b000001, 1, 2, 0,
-					android.bluetooth.le.ScanResult.TX_POWER_NOT_PRESENT, -70,
-					android.bluetooth.le.ScanResult.PERIODIC_INTERVAL_NOT_PRESENT, _record,
-					123456789L);
-
-			// Convert to support.v18.ScanResult
-			final BluetoothLeScannerImplOreo impl = new BluetoothLeScannerImplOreo();
-			final ScanResult result = impl.fromNativeScanResult(_result);
-
-			// Validate
-			assertEquals(_result.isLegacy(), result.isLegacy());
-			assertEquals(_result.isConnectable(), result.isConnectable());
-			assertEquals(ScanResult.DATA_COMPLETE, result.getDataStatus());
-			assertNotNull(result.getScanRecord());
-			final ScanRecord record = result.getScanRecord();
-			assertEquals(6, record.getAdvertiseFlags());
-			assertArrayEquals(bytes, record.getBytes());
-			assertNotNull(record.getManufacturerSpecificData(0x0059));
-			assertArrayEquals(_record.getManufacturerSpecificData(0x0059),
-					record.getManufacturerSpecificData(0x0059));
-			assertEquals(ScanResult.PERIODIC_INTERVAL_NOT_PRESENT, result.getPeriodicAdvertisingInterval());
-			assertEquals(ScanResult.TX_POWER_NOT_PRESENT, result.getTxPower());
-			assertEquals(123456789L, result.getTimestampNanos());
-			assertSame(_result.getDevice(), result.getDevice());
-			assertSame(device, result.getDevice());
-		} catch (Exception e) {
-			fail(e.getMessage());
+			final Method method = scanRecordClass.getDeclaredMethod("parseFromBytes", byte[].class);
+			return (android.bluetooth.le.ScanRecord) method.invoke(null, bytes);
+		} catch (NoSuchMethodException | IllegalAccessException | IllegalArgumentException
+				| InvocationTargetException e) {
+			return null;
 		}
 	}
 }

--- a/scanner/src/androidTest/java/no/nordicsemi/android/support/v18/scanner/BluetoothUuidTest.java
+++ b/scanner/src/androidTest/java/no/nordicsemi/android/support/v18/scanner/BluetoothUuidTest.java
@@ -17,28 +17,30 @@
 package no.nordicsemi.android.support.v18.scanner;
 
 import android.os.ParcelUuid;
+
 import org.junit.Test;
 
-import static junit.framework.Assert.assertEquals;
+import static com.google.common.truth.Truth.assertThat;
 
 public class BluetoothUuidTest {
 
-  @Test public void testUuidParser() {
-    byte[] uuid16 = new byte[] {
-        0x0B, 0x11
-    };
-    assertEquals(ParcelUuid.fromString("0000110B-0000-1000-8000-00805F9B34FB"),
-        BluetoothUuid.parseUuidFrom(uuid16));
-    byte[] uuid32 = new byte[] {
-        0x0B, 0x11, 0x33, (byte) 0xFE
-    };
-    assertEquals(ParcelUuid.fromString("FE33110B-0000-1000-8000-00805F9B34FB"),
-        BluetoothUuid.parseUuidFrom(uuid32));
-    byte[] uuid128 = new byte[] {
-        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
-        (byte) 0xFF
-    };
-    assertEquals(ParcelUuid.fromString("FF0F0E0D-0C0B-0A09-0807-0060504030201"),
-        BluetoothUuid.parseUuidFrom(uuid128));
-  }
+	@Test
+	public void testUuidParser() {
+		final byte[] uuid16 = new byte[]{
+				0x0B, 0x11
+		};
+		assertThat(BluetoothUuid.parseUuidFrom(uuid16))
+				.isEqualTo(ParcelUuid.fromString("0000110B-0000-1000-8000-00805F9B34FB"));
+		final byte[] uuid32 = new byte[]{
+				0x0B, 0x11, 0x33, (byte) 0xFE
+		};
+		assertThat(BluetoothUuid.parseUuidFrom(uuid32))
+				.isEqualTo(ParcelUuid.fromString("FE33110B-0000-1000-8000-00805F9B34FB"));
+		final byte[] uuid128 = new byte[]{
+				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+				(byte) 0xFF
+		};
+		assertThat(BluetoothUuid.parseUuidFrom(uuid128))
+				.isEqualTo(ParcelUuid.fromString("FF0F0E0D-0C0B-0A09-0807-0060504030201"));
+	}
 }

--- a/scanner/src/androidTest/java/no/nordicsemi/android/support/v18/scanner/ScanRecordTest.java
+++ b/scanner/src/androidTest/java/no/nordicsemi/android/support/v18/scanner/ScanRecordTest.java
@@ -17,50 +17,44 @@
 package no.nordicsemi.android.support.v18.scanner;
 
 import android.os.ParcelUuid;
-import androidx.test.runner.AndroidJUnit4;
-import java.util.Arrays;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-@RunWith(AndroidJUnit4.class) public class ScanRecordTest {
+import static com.google.common.truth.Truth.assertThat;
 
-  @Test public void testParser() {
-    byte[] scanRecord = new byte[] {
-        0x02, 0x01, 0x1a, // advertising flags
-        0x05, 0x02, 0x0b, 0x11, 0x0a, 0x11, // 16 bit service uuids
-        0x04, 0x09, 0x50, 0x65, 0x64, // name
-        0x02, 0x0A, (byte) 0xec, // tx power level
-        0x05, 0x16, 0x0b, 0x11, 0x50, 0x64, // service data
-        0x05, (byte) 0xff, (byte) 0xe0, 0x00, 0x02, 0x15, // manufacturer specific data
-        0x03, 0x50, 0x01, 0x02, // an unknown data type won't cause trouble
-    };
-    ScanRecord data = ScanRecord.parseFromBytes(scanRecord);
-    assertEquals(0x1a, data.getAdvertiseFlags());
-    ParcelUuid uuid1 = ParcelUuid.fromString("0000110A-0000-1000-8000-00805F9B34FB");
-    ParcelUuid uuid2 = ParcelUuid.fromString("0000110B-0000-1000-8000-00805F9B34FB");
-    assertTrue(data.getServiceUuids().contains(uuid1));
-    assertTrue(data.getServiceUuids().contains(uuid2));
-    assertEquals("Ped", data.getDeviceName());
-    assertEquals(-20, data.getTxPowerLevel());
-    assertTrue(data.getManufacturerSpecificData().get(0x00E0) != null);
-    assertArrayEquals(new byte[] {
-        0x02, 0x15
-    }, data.getManufacturerSpecificData().get(0x00E0));
-    assertTrue(data.getServiceData().containsKey(uuid2));
-    assertArrayEquals(new byte[] {
-        0x50, 0x64
-    }, data.getServiceData().get(uuid2));
-  }
+@RunWith(AndroidJUnit4.class)
+public class ScanRecordTest {
 
-  // Assert two byte arrays are equal.
-  private static void assertArrayEquals(byte[] expected, byte[] actual) {
-    if (!Arrays.equals(expected, actual)) {
-      fail("expected:<" + Arrays.toString(expected) +
-          "> but was:<" + Arrays.toString(actual) + ">");
-    }
-  }
+	@Test
+	public void testParser() {
+		final byte[] scanRecord = new byte[]{
+				0x02, 0x01, 0x1a,                                 // Flags
+				0x05, 0x02, 0x0b, 0x11, 0x0a, 0x11,               // Incomplete List of 16-bit Service Class UUIDs
+				0x04, 0x09, 0x50, 0x65, 0x64,                     // Complete Local Name
+				0x02, 0x0A, (byte) 0xec,                          // Tx Power Level
+				0x05, 0x16, 0x0b, 0x11, 0x50, 0x64,               // Service Data - 16-bit UUID
+				0x05, (byte) 0xff, (byte) 0xe0, 0x00, 0x02, 0x15, // Manufacturer Specific Data
+				0x03, 0x50, 0x01, 0x02,                           // An unknown data type won't cause trouble
+		};
+		final ScanRecord data = ScanRecord.parseFromBytes(scanRecord);
+		assertThat(data).isNotNull();
+		assertThat(data.getAdvertiseFlags()).isEqualTo(0x1a);
+		final ParcelUuid uuid1 = ParcelUuid.fromString("0000110A-0000-1000-8000-00805F9B34FB");
+		final ParcelUuid uuid2 = ParcelUuid.fromString("0000110B-0000-1000-8000-00805F9B34FB");
+		assertThat(data.getServiceUuids()).contains(uuid1);
+		assertThat(data.getServiceUuids()).contains(uuid2);
+		assertThat(data.getDeviceName()).isEqualTo("Ped");
+		assertThat(data.getTxPowerLevel()).isEqualTo(-20);
+		assertThat(data.getManufacturerSpecificData()).isNotNull();
+		assertThat(data.getManufacturerSpecificData().get(0x00E0)).isNotNull();
+		assertThat(data.getManufacturerSpecificData().get(0x00E0))
+				.isEqualTo(new byte[] { 0x02, 0x15});
+		assertThat(data.getServiceData()).isNotNull();
+		assertThat(data.getServiceData()).containsKey(uuid2);
+		assertThat(data.getServiceData().get(uuid2))
+				.isEqualTo(new byte[] { 0x50, 0x64});
+	}
 }

--- a/scanner/src/androidTest/java/no/nordicsemi/android/support/v18/scanner/ScanResultTest.java
+++ b/scanner/src/androidTest/java/no/nordicsemi/android/support/v18/scanner/ScanResultTest.java
@@ -19,29 +19,29 @@ package no.nordicsemi.android.support.v18.scanner;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.os.Parcel;
-import androidx.test.runner.AndroidJUnit4;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static junit.framework.Assert.assertEquals;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-@RunWith(AndroidJUnit4.class) public class ScanResultTest {
+import static com.google.common.truth.Truth.assertThat;
 
-  @Test public void testScanResultParceling() {
-    BluetoothDevice device =
-        BluetoothAdapter.getDefaultAdapter().getRemoteDevice("01:02:03:04:05:06");
-    byte[] scanRecord = new byte[] {
-        1, 2, 3
-    };
-    int rssi = -10;
-    long timestampMicros = 10000L;
-    ScanResult result =
-        new ScanResult(device, ScanRecord.parseFromBytes(scanRecord), rssi, timestampMicros);
-    Parcel parcel = Parcel.obtain();
-    result.writeToParcel(parcel, 0);
-    // Need to reset parcel data position to the beginning.
-    parcel.setDataPosition(0);
-    ScanResult resultFromParcel = ScanResult.CREATOR.createFromParcel(parcel);
-    assertEquals(result, resultFromParcel);
-  }
+@RunWith(AndroidJUnit4.class)
+public class ScanResultTest {
+
+	@Test
+	public void testScanResultParceling() {
+		final BluetoothDevice device = BluetoothAdapter.getDefaultAdapter()
+                .getRemoteDevice("01:02:03:04:05:06");
+		final byte[] scanRecord = new byte[] { 2, 1, 3 };
+		final ScanResult result =
+				new ScanResult(device, ScanRecord.parseFromBytes(scanRecord), -10, 10000L);
+		final Parcel parcel = Parcel.obtain();
+		result.writeToParcel(parcel, 0);
+		// Need to reset parcel data position to the beginning.
+		parcel.setDataPosition(0);
+		ScanResult resultFromParcel = ScanResult.CREATOR.createFromParcel(parcel);
+		assertThat(result).isEqualTo(resultFromParcel);
+	}
 }

--- a/scanner/src/androidTest/java/no/nordicsemi/android/support/v18/scanner/ScanSettingsTest.java
+++ b/scanner/src/androidTest/java/no/nordicsemi/android/support/v18/scanner/ScanSettingsTest.java
@@ -16,42 +16,36 @@
 
 package no.nordicsemi.android.support.v18.scanner;
 
-import androidx.test.runner.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static junit.framework.Assert.fail;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-@RunWith(AndroidJUnit4.class) public class ScanSettingsTest {
+import static org.junit.Assert.assertThrows;
 
-  @Test public void testCallbackType() {
-    ScanSettings.Builder builder = new ScanSettings.Builder();
-    builder.setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES);
-    builder.setCallbackType(ScanSettings.CALLBACK_TYPE_FIRST_MATCH);
-    builder.setCallbackType(ScanSettings.CALLBACK_TYPE_MATCH_LOST);
-    builder.setCallbackType(
-        ScanSettings.CALLBACK_TYPE_FIRST_MATCH | ScanSettings.CALLBACK_TYPE_MATCH_LOST);
-    try {
-      builder.setCallbackType(
-          ScanSettings.CALLBACK_TYPE_ALL_MATCHES | ScanSettings.CALLBACK_TYPE_MATCH_LOST);
-      fail("should have thrown IllegalArgumentException!");
-    } catch (IllegalArgumentException e) {
-      // nothing to do
-    }
-    try {
-      builder.setCallbackType(
-          ScanSettings.CALLBACK_TYPE_ALL_MATCHES | ScanSettings.CALLBACK_TYPE_FIRST_MATCH);
-      fail("should have thrown IllegalArgumentException!");
-    } catch (IllegalArgumentException e) {
-      // nothing to do
-    }
-    try {
-      builder.setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES |
-          ScanSettings.CALLBACK_TYPE_FIRST_MATCH |
-          ScanSettings.CALLBACK_TYPE_MATCH_LOST);
-      fail("should have thrown IllegalArgumentException!");
-    } catch (IllegalArgumentException e) {
-      // nothing to do
-    }
-  }
+@RunWith(AndroidJUnit4.class)
+public class ScanSettingsTest {
+
+	@Test
+	public void testCallbackType() {
+		final ScanSettings.Builder builder = new ScanSettings.Builder();
+		builder.setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES);
+		builder.setCallbackType(ScanSettings.CALLBACK_TYPE_FIRST_MATCH);
+		builder.setCallbackType(ScanSettings.CALLBACK_TYPE_MATCH_LOST);
+		builder.setCallbackType(
+				ScanSettings.CALLBACK_TYPE_FIRST_MATCH | ScanSettings.CALLBACK_TYPE_MATCH_LOST);
+		assertThrows(IllegalArgumentException.class, () ->
+				builder.setCallbackType(
+						ScanSettings.CALLBACK_TYPE_ALL_MATCHES | ScanSettings.CALLBACK_TYPE_MATCH_LOST)
+		);
+		assertThrows(IllegalArgumentException.class, () ->
+			builder.setCallbackType(
+					ScanSettings.CALLBACK_TYPE_ALL_MATCHES | ScanSettings.CALLBACK_TYPE_FIRST_MATCH)
+		);
+		assertThrows(IllegalArgumentException.class, () ->
+			builder.setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES |
+					ScanSettings.CALLBACK_TYPE_FIRST_MATCH |
+					ScanSettings.CALLBACK_TYPE_MATCH_LOST)
+		);
+	}
 }

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplJB.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplJB.java
@@ -155,11 +155,13 @@ import androidx.annotation.RequiresPermission;
 	/* package */ void startScanInternal(@NonNull final List<ScanFilter> filters,
 										 @NonNull final ScanSettings settings,
 										 @NonNull final Context context,
-										 @NonNull final PendingIntent callbackIntent) {
+										 @NonNull final PendingIntent callbackIntent,
+										 final int requestCode) {
 		final Intent service = new Intent(context, ScannerService.class);
 		service.putParcelableArrayListExtra(ScannerService.EXTRA_FILTERS, new ArrayList<>(filters));
 		service.putExtra(ScannerService.EXTRA_SETTINGS, settings);
 		service.putExtra(ScannerService.EXTRA_PENDING_INTENT, callbackIntent);
+		service.putExtra(ScannerService.EXTRA_REQUEST_CODE, requestCode);
 		service.putExtra(ScannerService.EXTRA_START, true);
 		context.startService(service);
 	}
@@ -167,9 +169,11 @@ import androidx.annotation.RequiresPermission;
 	@Override
 	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 	/* package */ void stopScanInternal(@NonNull final Context context,
-										@NonNull final PendingIntent callbackIntent) {
+										@NonNull final PendingIntent callbackIntent,
+										final int requestCode) {
 		final Intent service = new Intent(context, ScannerService.class);
 		service.putExtra(ScannerService.EXTRA_PENDING_INTENT, callbackIntent);
+		service.putExtra(ScannerService.EXTRA_REQUEST_CODE, requestCode);
 		service.putExtra(ScannerService.EXTRA_START, false);
 		context.startService(service);
 	}

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplLollipop.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplLollipop.java
@@ -107,7 +107,8 @@ import androidx.annotation.RequiresPermission;
 		/* package */ void startScanInternal(@NonNull final List<ScanFilter> filters,
 											 @NonNull final ScanSettings settings,
 											 @NonNull final Context context,
-											 @NonNull final PendingIntent callbackIntent) {
+											 @NonNull final PendingIntent callbackIntent,
+											 final int requestCode) {
 		final BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
 		final BluetoothLeScanner scanner = adapter.getBluetoothLeScanner();
 		if (scanner == null)
@@ -117,6 +118,7 @@ import androidx.annotation.RequiresPermission;
 		service.putParcelableArrayListExtra(ScannerService.EXTRA_FILTERS, new ArrayList<>(filters));
 		service.putExtra(ScannerService.EXTRA_SETTINGS, settings);
 		service.putExtra(ScannerService.EXTRA_PENDING_INTENT, callbackIntent);
+		service.putExtra(ScannerService.EXTRA_REQUEST_CODE, requestCode);
 		service.putExtra(ScannerService.EXTRA_START, true);
 		context.startService(service);
 	}
@@ -124,9 +126,11 @@ import androidx.annotation.RequiresPermission;
 	@Override
 	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 		/* package */ void stopScanInternal(@NonNull final Context context,
-											@NonNull final PendingIntent callbackIntent) {
+											@NonNull final PendingIntent callbackIntent,
+											final int requestCode) {
 		final Intent service = new Intent(context, ScannerService.class);
 		service.putExtra(ScannerService.EXTRA_PENDING_INTENT, callbackIntent);
+		service.putExtra(ScannerService.EXTRA_REQUEST_CODE, requestCode);
 		service.putExtra(ScannerService.EXTRA_START, false);
 		context.startService(service);
 	}

--- a/scanner/src/test/java/no/nordicsemi/android/support/v18/scanner/ObjectsTest.java
+++ b/scanner/src/test/java/no/nordicsemi/android/support/v18/scanner/ObjectsTest.java
@@ -2,9 +2,7 @@ package no.nordicsemi.android.support.v18.scanner;
 
 import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
+import static com.google.common.truth.Truth.assertThat;
 
 public class ObjectsTest {
 
@@ -16,8 +14,7 @@ public class ObjectsTest {
     final String nullString = Objects.toString(objectA);
 
     // Then
-    assertThat(nullString, is(notNullValue()));
-    assertThat(nullString, is("null"));
+    assertThat(nullString).isEqualTo("null");
   }
 
   @Test public void toString_nonNullValueAsParam_returnObjectToStringValue() {
@@ -32,30 +29,7 @@ public class ObjectsTest {
     final String nonNullString = Objects.toString(objectA);
 
     // Then
-    assertThat(nonNullString, is(nonNullString));
-    assertThat(nonNullString, is("notNull"));
-  }
-
-  @Test public void hash_nullValueAsParam_returnNumber() {
-    // Given
-    final Object nullObject = null;
-
-    // When
-    final int hash = Objects.hash(nullObject);
-
-    // Then
-    assertThat(hash, is(notNullValue()));
-  }
-
-  @Test public void hash_ObjectValueAsParam_returnNumber() {
-    // Given
-    final Object objectA = new Object();
-
-    // When
-    final int hash = Objects.hash(objectA);
-
-    // Then
-    assertThat(hash, is(notNullValue()));
+    assertThat(nonNullString).isEqualTo("notNull");
   }
 
   @Test public void equals_nullValueAsFirstParam_returnFalse() {
@@ -64,10 +38,11 @@ public class ObjectsTest {
     final Object objectB = new Object();
 
     // When
+    //noinspection ConstantConditions
     final boolean result = Objects.equals(objectA, objectB);
 
     // Then
-    assertThat(result, is(false));
+    assertThat(result).isFalse();
   }
 
   @Test public void equals_nullValueAsSecondParam_returnFalse() {
@@ -79,7 +54,7 @@ public class ObjectsTest {
     final boolean result = Objects.equals(objectA, objectB);
 
     // Then
-    assertThat(result, is(false));
+    assertThat(result).isFalse();
   }
 
   @Test public void equals_nullValueAsBothParams_returnTrue() {
@@ -88,10 +63,11 @@ public class ObjectsTest {
     final Object objectB = null;
 
     // When
+    //noinspection ConstantConditions
     final boolean result = Objects.equals(objectA, objectB);
 
     // Then
-    assertThat(result, is(true));
+    assertThat(result).isTrue();
   }
 
   @Test public void equals_differentBooleanParams_returnFalse() {
@@ -103,7 +79,7 @@ public class ObjectsTest {
     final boolean result = Objects.equals(paramA, paramB);
 
     // Then
-    assertThat(result, is(false));
+    assertThat(result).isFalse();
   }
 
   @Test public void equals_sameBooleanParams_returnTrue() {
@@ -115,7 +91,7 @@ public class ObjectsTest {
     final boolean result = Objects.equals(paramA, paramB);
 
     // Then
-    assertThat(result, is(true));
+    assertThat(result).isTrue();
   }
 
 }


### PR DESCRIPTION
This version fixes #58 by adding an additional parameter to `startScan` and `stopScan` when scanning with `PendingIntent`.

**Note:** As tests have been migrated to [truth](https://truth.dev/), they will not compile as they require Java 8. A new version 1.5.0 will be released with Java 8 support.