### PR TITLE
Bug fix: Weakening references to user-given scan callbacks

### DIFF
--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplOreo.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplOreo.java
@@ -284,10 +284,10 @@ import androidx.annotation.RequiresPermission;
 									 final boolean offloadedFilteringSupported,
 									 @NonNull final List<ScanFilter> filters,
 									 @NonNull final ScanSettings settings,
-									 @NonNull final PendingIntent callbackIntent) {
+									 @NonNull final PendingIntentExecutor executor) {
 			super(offloadedBatchingSupported, offloadedFilteringSupported, filters, settings,
-					new PendingIntentExecutor(callbackIntent, settings), new Handler());
-			executor = (PendingIntentExecutor) scanCallback;
+					executor, new Handler());
+			this.executor = executor;
 		}
 	}
 }

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/PendingIntentReceiver.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/PendingIntentReceiver.java
@@ -97,8 +97,13 @@ public class PendingIntentReceiver extends BroadcastReceiver {
 			if (wrapper == null) {
 				// Wrapper has not been created, or was created, but the app was then killed
 				// and must be created again. Some information will be lost (batched devices).
-				wrapper = new BluetoothLeScannerImplOreo.PendingIntentExecutorWrapper(offloadedBatchingSupported,
-						offloadedFilteringSupported, filters, settings, callbackIntent);
+				final PendingIntentExecutor executor = new PendingIntentExecutor(callbackIntent, settings);
+				wrapper = new BluetoothLeScannerImplOreo.PendingIntentExecutorWrapper(
+						offloadedBatchingSupported,
+						offloadedFilteringSupported,
+						filters, settings,
+						executor
+				);
 				scannerImpl.addWrapper(callbackIntent, wrapper);
 			}
 		}

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScanCallbackWrapperSet.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/ScanCallbackWrapperSet.java
@@ -1,0 +1,90 @@
+package no.nordicsemi.android.support.v18.scanner;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+class ScanCallbackWrapperSet<W extends BluetoothLeScannerCompat.ScanCallbackWrapper> {
+	@NonNull
+	private final Set<W> wrappers = new HashSet<>();
+
+	@NonNull
+	public Set<W> values() {
+		return wrappers;
+	}
+
+	boolean isEmpty() {
+		return wrappers.isEmpty();
+	}
+
+	void add(@NonNull final W wrapper) {
+		wrappers.add(wrapper);
+	}
+
+	boolean contains(@NonNull final ScanCallback callback) {
+		for (final W wrapper : wrappers) {
+			if (wrapper.scanCallback == callback) {
+				return true;
+			}
+			if (wrapper.scanCallback instanceof UserScanCallbackWrapper) {
+				final UserScanCallbackWrapper callbackWrapper = (UserScanCallbackWrapper) wrapper.scanCallback;
+				if (callbackWrapper.get() == callback) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	@Nullable
+	W get(@NonNull final ScanCallback callback) {
+		for (final W wrapper : wrappers) {
+			if (wrapper.scanCallback == callback) {
+				return wrapper;
+			}
+			if (wrapper.scanCallback instanceof UserScanCallbackWrapper) {
+				final UserScanCallbackWrapper callbackWrapper = (UserScanCallbackWrapper) wrapper.scanCallback;
+				if (callbackWrapper.get() == callback) {
+					return wrapper;
+				}
+			}
+		}
+		return null;
+	}
+
+	@Nullable
+	W remove(@NonNull final ScanCallback callback) {
+		for (final W wrapper : wrappers) {
+			if (wrapper.scanCallback == callback) {
+				return wrapper;
+			}
+			if (wrapper.scanCallback instanceof UserScanCallbackWrapper) {
+				final UserScanCallbackWrapper callbackWrapper = (UserScanCallbackWrapper) wrapper.scanCallback;
+				if (callbackWrapper.get() == callback) {
+					wrappers.remove(wrapper);
+					return wrapper;
+				}
+			}
+		}
+		cleanUp();
+		return null;
+	}
+
+	private void cleanUp() {
+		final List<W> deadWrappers = new LinkedList<>();
+		for (final W wrapper : wrappers) {
+			if (wrapper.scanCallback instanceof UserScanCallbackWrapper) {
+				final UserScanCallbackWrapper callbackWrapper = (UserScanCallbackWrapper) wrapper.scanCallback;
+				if (callbackWrapper.isDead())
+					deadWrappers.add(wrapper);
+			}
+		}
+		for (final W wrapper : deadWrappers) {
+			wrappers.remove(wrapper);
+		}
+	}
+}

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/UserScanCallbackWrapper.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/UserScanCallbackWrapper.java
@@ -1,0 +1,52 @@
+package no.nordicsemi.android.support.v18.scanner;
+
+import java.lang.ref.WeakReference;
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * This class wraps the {@link ScanCallback} object given by the user and holds a weak reference
+ * to it. This prevents from leaking object if the callbacks are held by Activities,
+ * Fragments or View Models.
+ *
+ * See https://github.com/NordicSemiconductor/Android-Scanner-Compat-Library/issues/109
+ */
+/* package */ class UserScanCallbackWrapper extends ScanCallback {
+	private final WeakReference<ScanCallback> weakScanCallback;
+
+	UserScanCallbackWrapper(@NonNull final ScanCallback userCallback) {
+		weakScanCallback = new WeakReference<>(userCallback);
+	}
+
+	boolean isDead() {
+		return weakScanCallback.get() == null;
+	}
+
+	@Nullable
+	ScanCallback get() {
+		return weakScanCallback.get();
+	}
+
+	@Override
+	public void onScanResult(final int callbackType, @NonNull final ScanResult result) {
+		final ScanCallback userCallback = weakScanCallback.get();
+		if (userCallback != null)
+			userCallback.onScanResult(callbackType, result);
+	}
+
+	@Override
+	public void onBatchScanResults(@NonNull final List<ScanResult> results) {
+		final ScanCallback userCallback = weakScanCallback.get();
+		if (userCallback != null)
+			userCallback.onBatchScanResults(results);
+	}
+
+	@Override
+	public void onScanFailed(final int errorCode) {
+		final ScanCallback userCallback = weakScanCallback.get();
+		if (userCallback != null)
+			userCallback.onScanFailed(errorCode);
+	}
+}


### PR DESCRIPTION
This PR aims to fix #109. The references to `ScanCallback` instances given by the user were weakened which should prevent from leaking them. No changes in user's code are required.