### PR TITLE
Migration to Android 12

### DIFF
--- a/moustache/README.mo
+++ b/moustache/README.mo
@@ -34,7 +34,7 @@ following dependency:
 implementation 'no.nordicsemi.android.support.v18:scanner:{{VERSION}}'
 ```
 
-If you are not targeting API 31 (Android 12), use version 1.5.1.
+Project not targeting API 31 (Android 12) or newer should use version 1.5.1.
 
 Projects not migrated to Android Jetpack should use version 1.3.1, which is feature-equal to 1.4.0.
 

--- a/moustache/README.mo
+++ b/moustache/README.mo
@@ -22,6 +22,9 @@ This is much less battery friendly than when the original method is used, but wo
 a lot of development time if such feature should be implemented anyway. Please read below 
 for more details.
 
+Note, that for unfiltered scans, scanning is stopped on screen off to save power. Scanning is
+resumed when screen is turned on again. To avoid this, use scanning with desired ScanFilter.
+
 ## Usage
 
 The compat library may be found on Maven Central repository. Add it to your project by adding the 
@@ -30,6 +33,8 @@ following dependency:
 ```Groovy
 implementation 'no.nordicsemi.android.support.v18:scanner:{{VERSION}}'
 ```
+
+If you are not targeting API 31 (Android 12), use version 1.5.1.
 
 Projects not migrated to Android Jetpack should use version 1.3.1, which is feature-equal to 1.4.0.
 
@@ -57,10 +62,21 @@ already enabled desugaring. But if this causes problems for you, please use vers
 
 Following [this](https://developer.android.com/reference/android/bluetooth/le/BluetoothLeScanner#startScan(android.bluetooth.le.ScanCallback)) link:
 
-> An app must have [ACCESS_COARSE_LOCATION](https://developer.android.com/reference/android/Manifest.permission#ACCESS_COARSE_LOCATION) permission in order to get results. An App targeting Android Q or later must have [ACCESS_FINE_LOCATION](https://developer.android.com/reference/android/Manifest.permission#ACCESS_FINE_LOCATION) permission in order to get results.
-For apps targeting [Build.VERSION_CODES#R](https://developer.android.com/reference/android/os/Build.VERSION_CODES#R) or lower, this requires the [Manifest.permission#BLUETOOTH_ADMIN](https://developer.android.com/reference/android/Manifest.permission#BLUETOOTH_ADMIN) permission which can be gained with a simple `<uses-permission>` manifest tag.
-For apps targeting [Build.VERSION_CODES#S](https://developer.android.com/reference/android/os/Build.VERSION_CODES#S) or or higher, this requires the [Manifest.permission#BLUETOOTH_SCAN](https://developer.android.com/reference/android/Manifest.permission#BLUETOOTH_SCAN) permission which can be gained with [Activity.requestPermissions(String[], int)](https://developer.android.com/reference/android/app/Activity#requestPermissions(java.lang.String[],%20int)).
-In addition, this requires either the [Manifest.permission#ACCESS_FINE_LOCATION](https://developer.android.com/reference/android/Manifest.permission#ACCESS_FINE_LOCATION) permission or a strong assertion that you will never derive the physical location of the device. You can make this assertion by declaring `usesPermissionFlags="neverForLocation"` on the relevant `<uses-permission>` manifest tag, but it may restrict the types of Bluetooth devices you can interact with.
+> An app must have [ACCESS_COARSE_LOCATION](https://developer.android.com/reference/android/Manifest.permission#ACCESS_COARSE_LOCATION)
+permission in order to get results. An App targeting Android Q or later must have
+[ACCESS_FINE_LOCATION](https://developer.android.com/reference/android/Manifest.permission#ACCESS_FINE_LOCATION)
+permission in order to get results.
+For apps targeting [Build.VERSION_CODES#R](https://developer.android.com/reference/android/os/Build.VERSION_CODES#R)
+or lower, this requires the [Manifest.permission#BLUETOOTH_ADMIN](https://developer.android.com/reference/android/Manifest.permission#BLUETOOTH_ADMIN)
+permission which can be gained with a simple `<uses-permission>` manifest tag.
+For apps targeting [Build.VERSION_CODES#S](https://developer.android.com/reference/android/os/Build.VERSION_CODES#S)
+or or higher, this requires the [Manifest.permission#BLUETOOTH_SCAN](https://developer.android.com/reference/android/Manifest.permission#BLUETOOTH_SCAN)
+permission which can be gained with
+[Activity.requestPermissions(String[], int)](https://developer.android.com/reference/android/app/Activity#requestPermissions(java.lang.String[],%20int)).
+In addition, this requires either the [Manifest.permission#ACCESS_FINE_LOCATION](https://developer.android.com/reference/android/Manifest.permission#ACCESS_FINE_LOCATION)
+permission or a strong assertion that you will never derive the physical location of the device.
+You can make this assertion by declaring `usesPermissionFlags="neverForLocation"` on the relevant
+`<uses-permission>` manifest tag, but it may restrict the types of Bluetooth devices you can interact with.
 
 ## API
 
@@ -178,7 +194,7 @@ the application. No changes are required to make it work.
 To use this feature:
 
 ```java
-    Intent intent = new Intent(context, MyReceiver.class); // explicite intent 
+    Intent intent = new Intent(context, MyReceiver.class); // explicit intent
 	intent.setAction("com.example.ACTION_FOUND");
 	intent.putExtra("some.extra", value); // optional
 	PendingIntent pendingIntent = PendingIntent.getBroadcast(context, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT);
@@ -193,7 +209,7 @@ To use this feature:
 	scanner.startScan(filters, settings, context, pendingIntent, requestCode);
 ```
 
-Add your `MyRecever` to *AndroidManifest*, as the application context might have been released 
+Add your `MyReceiver` to *AndroidManifest*, as the application context might have been released
 and all broadcast receivers registered to it together with it.
 
 To stop scanning call:
@@ -226,6 +242,9 @@ should be used, together with report delay set and filters used.
 Background scanning on Android 4.3 and 4.4.x will use a lot of power, as all those properties 
 will have to be emulated. It is recommended to scan in background only on Lollipop or newer, or
 even Oreo or newer devices and giving the user an option to disable this feature.
+
+Note, that for unfiltered scans, scanning is stopped on screen off to save power. Scanning is
+resumed when screen is turned on again. To avoid this, use scanning with desired ScanFilter.
 
 ## License
 

--- a/scanner/build.gradle
+++ b/scanner/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 18
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 21
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -18,10 +18,6 @@ android {
         debug {
             testCoverageEnabled true
         }
-    }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 

--- a/scanner/src/main/AndroidManifest.xml
+++ b/scanner/src/main/AndroidManifest.xml
@@ -4,11 +4,7 @@
 
 	<!--
 	 Bluetooth permissions require to check Bluetooth Adapter state
-	 and starting LE scan.
-
-	 Note: For scanning purpose, the permissions below have been replaced with
-	       BLUETOOTH_SCAN in Android API 31 (Android 12).
-	       Due to possible use of flag, apps need to request the permission on their own.
+	 and starting LE scan before Android S (API 31).
 	-->
 	<uses-permission
 		android:name="android.permission.BLUETOOTH"
@@ -16,12 +12,20 @@
 	<uses-permission
 		android:name="android.permission.BLUETOOTH_ADMIN"
 		android:maxSdkVersion="30"/>
+	<!--
+	 Bluetooth Scan permission is required from Android S onwards.
+
+	 Note: This permission may be used with "usesPermissionFlag". If you don't need location,
+	       declare this permission with this flag set to "neverForLocation".
+	-->
+	<uses-permission
+		android:name="android.permission.BLUETOOTH_SCAN" />
 
 	<!--
 	 Location permission has been removed from here, as it may not be required for
-	 Android 12 onwards. Instead, apps should request BLUETOOTH_SCAN permission with or without
-	 "neverForLocation" flag, and the location permission only if necessary.
+	 Android 12 onwards. It is required on Android 6-11 when scanning for Bluetooth LE devices.
 
+	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 	-->
 

--- a/scanner/src/main/AndroidManifest.xml
+++ b/scanner/src/main/AndroidManifest.xml
@@ -3,16 +3,27 @@
 	xmlns:tools="http://schemas.android.com/tools">
 
 	<!--
-	Bluetooth permissions require to check Bluetooth Adapter state
-	and starting LE scan.
+	 Bluetooth permissions require to check Bluetooth Adapter state
+	 and starting LE scan.
+
+	 Note: For scanning purpose, the permissions below have been replaced with
+	       BLUETOOTH_SCAN in Android API 31 (Android 12).
+	       Due to possible use of flag, apps need to request the permission on their own.
 	-->
-	<uses-permission android:name="android.permission.BLUETOOTH"/>
-	<uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
+	<uses-permission
+		android:name="android.permission.BLUETOOTH"
+		android:maxSdkVersion="30"/>
+	<uses-permission
+		android:name="android.permission.BLUETOOTH_ADMIN"
+		android:maxSdkVersion="30"/>
+
 	<!--
-	Location permission is required on Android 6+.
-	Since Android 10 the FINE LOCATION will be required.
-	-->
+	 Location permission has been removed from here, as it may not be required for
+	 Android 12 onwards. Instead, apps should request BLUETOOTH_SCAN permission with or without
+	 "neverForLocation" flag, and the location permission only if necessary.
+
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+	-->
 
 	<application>
 		<!--

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerCompat.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerCompat.java
@@ -30,6 +30,9 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.SystemClock;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,10 +41,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.RequiresPermission;
 
 /**
  * This class provides methods to perform scan related operations for Bluetooth LE devices. An
@@ -111,18 +110,25 @@ public abstract class BluetoothLeScannerCompat {
 
 	/**
 	 * Start Bluetooth LE scan with default parameters and no filters. The scan results will be
-	 * delivered through {@code callback}.
+	 * delivered through {@code callback}. For unfiltered scans, scanning is stopped on screen
+	 * off to save power. Scanning is resumed when screen is turned on again. To avoid this, use
+	 * {@link #startScan(List, ScanSettings, ScanCallback)} with desired {@link ScanFilter}.
 	 * <p>
-	 * Requires {@link Manifest.permission#BLUETOOTH_ADMIN} permission.
-	 * An app must hold
-	 * {@link Manifest.permission#ACCESS_COARSE_LOCATION ACCESS_FINE_LOCATION} permission
-	 * in order to get results.
+	 * For apps targeting {@link Build.VERSION_CODES#R} or lower, this requires the
+	 * {@link Manifest.permission#BLUETOOTH_ADMIN} permission which can be gained with a simple
+	 * {@code <uses-permission>} manifest tag.
+	 * For apps targeting {@link Build.VERSION_CODES#S} or or higher, this requires the
+	 * {@link Manifest.permission#BLUETOOTH_SCAN} permission which can be gained with
+	 * {@link android.app.Activity#requestPermissions(String[], int)}.
+	 * In addition, this requires either the {@link Manifest.permission#ACCESS_FINE_LOCATION}
+	 * permission or a strong assertion that you will never derive the physical location of the device.
+	 * You can make this assertion by declaring {@code usesPermissionFlags="neverForLocation"}
+	 * on the relevant {@code <uses-permission>} manifest tag, but it may restrict the types of
+	 * Bluetooth devices you can interact with.
 	 *
 	 * @param callback Callback used to deliver scan results.
 	 * @throws IllegalArgumentException If {@code callback} is null.
 	 */
-	@SuppressWarnings("WeakerAccess")
-	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 	public final void startScan(@NonNull final ScanCallback callback) {
 		//noinspection ConstantConditions
 		if (callback == null) {
@@ -135,19 +141,27 @@ public abstract class BluetoothLeScannerCompat {
 
 	/**
 	 * Start Bluetooth LE scan. The scan results will be delivered through {@code callback}.
+	 * For unfiltered scans, scanning is stopped on screen off to save power. Scanning is
+	 * resumed when screen is turned on again. To avoid this, do filtered scanning by
+	 * using proper {@link ScanFilter}.
 	 * <p>
-	 * Requires {@link Manifest.permission#BLUETOOTH_ADMIN} permission.
-	 * An app must hold
-	 * {@link Manifest.permission#ACCESS_COARSE_LOCATION ACCESS_FINE_LOCATION} permission
-	 * in order to get results.
+	 * For apps targeting {@link Build.VERSION_CODES#R} or lower, this requires the
+	 * {@link Manifest.permission#BLUETOOTH_ADMIN} permission which can be gained with a simple
+	 * {@code <uses-permission>} manifest tag.
+	 * For apps targeting {@link Build.VERSION_CODES#S} or or higher, this requires the
+	 * {@link Manifest.permission#BLUETOOTH_SCAN} permission which can be gained with
+	 * {@link android.app.Activity#requestPermissions(String[], int)}.
+	 * In addition, this requires either the {@link Manifest.permission#ACCESS_FINE_LOCATION}
+	 * permission or a strong assertion that you will never derive the physical location of the device.
+	 * You can make this assertion by declaring {@code usesPermissionFlags="neverForLocation"}
+	 * on the relevant {@code <uses-permission>} manifest tag, but it may restrict the types of
+	 * Bluetooth devices you can interact with.
 	 *
 	 * @param filters {@link ScanFilter}s for finding exact BLE devices.
 	 * @param settings Optional settings for the scan.
 	 * @param callback Callback used to deliver scan results.
 	 * @throws IllegalArgumentException If {@code settings} or {@code callback} is null.
 	 */
-	@SuppressWarnings("unused")
-	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 	public final void startScan(@Nullable final List<ScanFilter> filters,
 								@Nullable final ScanSettings settings,
 								@NonNull  final ScanCallback callback) {
@@ -163,11 +177,21 @@ public abstract class BluetoothLeScannerCompat {
 
 	/**
 	 * Start Bluetooth LE scan. The scan results will be delivered through {@code callback}.
+	 * For unfiltered scans, scanning is stopped on screen off to save power. Scanning is
+	 * resumed when screen is turned on again. To avoid this, do filtered scanning by
+	 * using proper {@link ScanFilter}.
 	 * <p>
-	 * Requires {@link Manifest.permission#BLUETOOTH_ADMIN} permission.
-	 * An app must hold
-	 * {@link Manifest.permission#ACCESS_COARSE_LOCATION ACCESS_FINE_LOCATION} permission
-	 * in order to get results.
+	 * For apps targeting {@link Build.VERSION_CODES#R} or lower, this requires the
+	 * {@link Manifest.permission#BLUETOOTH_ADMIN} permission which can be gained with a simple
+	 * {@code <uses-permission>} manifest tag.
+	 * For apps targeting {@link Build.VERSION_CODES#S} or or higher, this requires the
+	 * {@link Manifest.permission#BLUETOOTH_SCAN} permission which can be gained with
+	 * {@link android.app.Activity#requestPermissions(String[], int)}.
+	 * In addition, this requires either the {@link Manifest.permission#ACCESS_FINE_LOCATION}
+	 * permission or a strong assertion that you will never derive the physical location of the device.
+	 * You can make this assertion by declaring {@code usesPermissionFlags="neverForLocation"}
+	 * on the relevant {@code <uses-permission>} manifest tag, but it may restrict the types of
+	 * Bluetooth devices you can interact with.
 	 *
 	 * @param filters {@link ScanFilter}s for finding exact BLE devices.
 	 * @param settings Optional settings for the scan.
@@ -175,8 +199,6 @@ public abstract class BluetoothLeScannerCompat {
 	 * @param handler  Optional handler used to deliver results.
 	 * @throws IllegalArgumentException If {@code settings} or {@code callback} is null.
 	 */
-	@SuppressWarnings("unused")
-	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 	public final void startScan(@Nullable final List<ScanFilter> filters,
 								@Nullable final ScanSettings settings,
 								@NonNull  final ScanCallback callback,
@@ -193,11 +215,15 @@ public abstract class BluetoothLeScannerCompat {
 	/**
 	 * Stops an ongoing Bluetooth LE scan.
 	 * <p>
-	 * Requires {@link Manifest.permission#BLUETOOTH_ADMIN} permission.
+	 * For apps targeting {@link Build.VERSION_CODES#R} or lower, this requires the
+	 * {@link Manifest.permission#BLUETOOTH_ADMIN} permission which can be gained with a simple
+	 * {@code <uses-permission>} manifest tag.
+	 * For apps targeting {@link Build.VERSION_CODES#S} or or higher, this requires the
+	 * {@link Manifest.permission#BLUETOOTH_SCAN} permission which can be gained with
+	 * {@link android.app.Activity#requestPermissions(String[], int)}.
 	 *
 	 * @param callback The callback used to start scanning.
 	 */
-	@RequiresPermission(Manifest.permission.BLUETOOTH_ADMIN)
 	public final void stopScan(@NonNull final ScanCallback callback) {
 		//noinspection ConstantConditions
 		if (callback == null) {
@@ -214,7 +240,6 @@ public abstract class BluetoothLeScannerCompat {
 	 * @param callback Callback used to deliver scan results.
 	 * @param handler  Handler used to deliver results.
 	 */
-	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 	/* package */ abstract void startScanInternal(@NonNull List<ScanFilter> filters,
 												  @NonNull ScanSettings settings,
 												  @NonNull ScanCallback callback,
@@ -225,13 +250,13 @@ public abstract class BluetoothLeScannerCompat {
 	 *
 	 * @param callback The callback used to start scanning.
 	 */
-	@RequiresPermission(Manifest.permission.BLUETOOTH_ADMIN)
 	/* package */ abstract void stopScanInternal(@NonNull ScanCallback callback);
 
 	/**
 	 * Start Bluetooth LE scan using a {@link PendingIntent}. The scan results will be delivered
-	 * via the PendingIntent. On platforms before Oreo this will start {@link ScannerService}
-	 * which will scan in background using given settings.
+	 * via the PendingIntent. Use this method of scanning if your process is not always running
+	 * and it should be started when scan results are available. On platforms before Oreo this
+	 * will start {@link ScannerService} which will scan in background using given settings.
 	 * <p>
 	 * Starting from Android Scanner Compat Library version 1.4.5, to start and stop a scan with
 	 * Pending Intent a request code needs to he given. The code for stopping the scan must
@@ -247,14 +272,21 @@ public abstract class BluetoothLeScannerCompat {
 	 * A {@link PendingIntentReceiver} and {@link ScannerService} will be added to AndroidManifest
 	 * whether this feature is used or not.
 	 * <p>
-	 * Requires {@link Manifest.permission#BLUETOOTH_ADMIN} permission.
-	 * An app must hold
-	 * {@link Manifest.permission#ACCESS_COARSE_LOCATION ACCESS_FINE_LOCATION} permission
-	 * in order to get results.
-	 * <p>
 	 * When the PendingIntent is delivered, the Intent passed to the receiver or activity will
 	 * contain one or more of the extras {@link #EXTRA_CALLBACK_TYPE}, {@link #EXTRA_ERROR_CODE} and
 	 * {@link #EXTRA_LIST_SCAN_RESULT} to indicate the result of the scan.
+	 * <p>
+	 * For apps targeting {@link Build.VERSION_CODES#R} or lower, this requires the
+	 * {@link Manifest.permission#BLUETOOTH_ADMIN} permission which can be gained with a simple
+	 * {@code <uses-permission>} manifest tag.
+	 * For apps targeting {@link Build.VERSION_CODES#S} or or higher, this requires the
+	 * {@link Manifest.permission#BLUETOOTH_SCAN} permission which can be gained with
+	 * {@link android.app.Activity#requestPermissions(String[], int)}.
+	 * In addition, this requires either the {@link Manifest.permission#ACCESS_FINE_LOCATION}
+	 * permission or a strong assertion that you will never derive the physical location of the device.
+	 * You can make this assertion by declaring {@code usesPermissionFlags="neverForLocation"}
+	 * on the relevant {@code <uses-permission>} manifest tag, but it may restrict the types of
+	 * Bluetooth devices you can interact with.
 	 *
 	 * @param filters        {@link ScanFilter}s for finding exact BLE devices.
 	 * @param settings       Optional settings for the scan.
@@ -264,7 +296,6 @@ public abstract class BluetoothLeScannerCompat {
 	 * @throws IllegalArgumentException If {@code settings} or {@code callback} is null.
 	 * @since 1.4.5
 	 */
-	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 	public final void startScan(@Nullable final List<ScanFilter> filters,
 								@Nullable final ScanSettings settings,
 								@NonNull  final Context context,
@@ -285,8 +316,14 @@ public abstract class BluetoothLeScannerCompat {
 
 	/**
 	 * Start Bluetooth LE scan using a {@link PendingIntent}. The scan results will be delivered
-	 * via the PendingIntent. On platforms before Oreo this will start {@link ScannerService}
-	 * which will scan in background using given settings.
+	 * via the PendingIntent. Use this method of scanning if your process is not always running
+	 * and it should be started when scan results are available. On platforms before Oreo this
+	 * will start {@link ScannerService} which will scan in background using given settings.
+	 * <p>
+	 * Starting from Android Scanner Compat Library version 1.4.5, to start and stop a scan with
+	 * Pending Intent a request code needs to he given. The code for stopping the scan must
+	 * be the same as one used to start the scan. It can be the same request code that was
+	 * used to create he Pending Intent.
 	 * <p>
 	 * This method of scanning is intended to work in background. Long running scanning may
 	 * consume a lot of battery, so it is recommended to use low power mode in settings,
@@ -297,14 +334,21 @@ public abstract class BluetoothLeScannerCompat {
 	 * A {@link PendingIntentReceiver} and {@link ScannerService} will be added to AndroidManifest
 	 * whether this feature is used or not.
 	 * <p>
-	 * Requires {@link Manifest.permission#BLUETOOTH_ADMIN} permission.
-	 * An app must hold
-	 * {@link Manifest.permission#ACCESS_COARSE_LOCATION ACCESS_FINE_LOCATION} permission
-	 * in order to get results.
-	 * <p>
 	 * When the PendingIntent is delivered, the Intent passed to the receiver or activity will
 	 * contain one or more of the extras {@link #EXTRA_CALLBACK_TYPE}, {@link #EXTRA_ERROR_CODE} and
 	 * {@link #EXTRA_LIST_SCAN_RESULT} to indicate the result of the scan.
+	 * <p>
+	 * For apps targeting {@link Build.VERSION_CODES#R} or lower, this requires the
+	 * {@link Manifest.permission#BLUETOOTH_ADMIN} permission which can be gained with a simple
+	 * {@code <uses-permission>} manifest tag.
+	 * For apps targeting {@link Build.VERSION_CODES#S} or or higher, this requires the
+	 * {@link Manifest.permission#BLUETOOTH_SCAN} permission which can be gained with
+	 * {@link android.app.Activity#requestPermissions(String[], int)}.
+	 * In addition, this requires either the {@link Manifest.permission#ACCESS_FINE_LOCATION}
+	 * permission or a strong assertion that you will never derive the physical location of the device.
+	 * You can make this assertion by declaring {@code usesPermissionFlags="neverForLocation"}
+	 * on the relevant {@code <uses-permission>} manifest tag, but it may restrict the types of
+	 * Bluetooth devices you can interact with.
 	 *
 	 * @param filters        {@link ScanFilter}s for finding exact BLE devices.
 	 * @param settings       Optional settings for the scan.
@@ -313,7 +357,6 @@ public abstract class BluetoothLeScannerCompat {
 	 * @throws IllegalArgumentException If {@code settings} or {@code callback} is null.
 	 * @see #startScan(List, ScanSettings, Context, PendingIntent, int)
 	 */
-	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 	public final void startScan(@Nullable final List<ScanFilter> filters,
 								@Nullable final ScanSettings settings,
 								@NonNull  final Context context,
@@ -324,7 +367,12 @@ public abstract class BluetoothLeScannerCompat {
 	/**
 	 * Stops an ongoing Bluetooth LE scan.
 	 * <p>
-	 * Requires {@link Manifest.permission#BLUETOOTH_ADMIN} permission.
+	 * For apps targeting {@link Build.VERSION_CODES#R} or lower, this requires the
+	 * {@link Manifest.permission#BLUETOOTH_ADMIN} permission which can be gained with a simple
+	 * {@code <uses-permission>} manifest tag.
+	 * For apps targeting {@link Build.VERSION_CODES#S} or or higher, this requires the
+	 * {@link Manifest.permission#BLUETOOTH_SCAN} permission which can be gained with
+	 * {@link android.app.Activity#requestPermissions(String[], int)}.
 	 *
 	 * @param context        Context used to stop {@link ScannerService}.
 	 * @param callbackIntent The PendingIntent that was used to start the scan.
@@ -332,7 +380,6 @@ public abstract class BluetoothLeScannerCompat {
 	 *                       as one used to start scan.
 	 * @since 1.4.5
 	 */
-	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 	public final void stopScan(@NonNull final Context context,
 							   @NonNull final PendingIntent callbackIntent,
 							   final int requestCode) {
@@ -348,22 +395,28 @@ public abstract class BluetoothLeScannerCompat {
 	}
 
 	/**
-	 * Stops an ongoing Bluetooth LE scan.
+	 * Stops an ongoing Bluetooth LE scan. If the scan was started using
+	 * {@link #startScan(List, ScanSettings, Context, PendingIntent, int)}, use
+	 * {@link #stopScan(Context, PendingIntent, int)} instead.
 	 * <p>
-	 * Requires {@link Manifest.permission#BLUETOOTH_ADMIN} permission.
+	 * For apps targeting {@link Build.VERSION_CODES#R} or lower, this requires the
+	 * {@link Manifest.permission#BLUETOOTH_ADMIN} permission which can be gained with a simple
+	 * {@code <uses-permission>} manifest tag.
+	 * For apps targeting {@link Build.VERSION_CODES#S} or or higher, this requires the
+	 * {@link Manifest.permission#BLUETOOTH_SCAN} permission which can be gained with
+	 * {@link android.app.Activity#requestPermissions(String[], int)}.
 	 *
 	 * @param context        Context used to stop {@link ScannerService}.
 	 * @param callbackIntent The PendingIntent that was used to start the scan.
 	 * @see #stopScan(Context, PendingIntent, int)
 	 */
-	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 	public final void stopScan(@NonNull final Context context,
 							   @NonNull final PendingIntent callbackIntent) {
 		stopScanInternal(context, callbackIntent, 0);
 	}
 
 	/**
-	 * Starts Bluetooth LE scan using PendingIntent.
+	 * Starts Bluetooth LE scan using {@link PendingIntent}.
 	 * Its implementation depends on the Android version.
 	 *
 	 * @param filters        {@link ScanFilter}s for finding exact BLE devices.
@@ -372,7 +425,6 @@ public abstract class BluetoothLeScannerCompat {
 	 * @param callbackIntent The PendingIntent to deliver the result to.
 	 * @param requestCode    The PendingIntent request code.
 	 */
-	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 	/* package */ abstract void startScanInternal(@NonNull List<ScanFilter> filters,
 												  @NonNull ScanSettings settings,
 												  @NonNull Context context,
@@ -387,7 +439,6 @@ public abstract class BluetoothLeScannerCompat {
 	 * @param requestCode    The PendingIntent request code. It must be the same that used for
 	 *                       starting scan.
 	 */
-	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 	/* package */ abstract void stopScanInternal(@NonNull Context context,
 												 @NonNull PendingIntent callbackIntent,
 												 final int requestCode);
@@ -396,11 +447,17 @@ public abstract class BluetoothLeScannerCompat {
 	 * Flush pending batch scan results stored in Bluetooth controller. This will return Bluetooth
 	 * LE scan results batched on Bluetooth controller. Returns immediately, batch scan results data
 	 * will be delivered through the {@code callback}.
+	 * <p>
+	 * For apps targeting {@link Build.VERSION_CODES#R} or lower, this requires the
+	 * {@link Manifest.permission#BLUETOOTH_ADMIN} permission which can be gained with a simple
+	 * {@code <uses-permission>} manifest tag.
+	 * For apps targeting {@link Build.VERSION_CODES#S} or or higher, this requires the
+	 * {@link Manifest.permission#BLUETOOTH_SCAN} permission which can be gained with
+	 * {@link android.app.Activity#requestPermissions(String[], int)}.
 	 *
 	 * @param callback Callback of the Bluetooth LE Scan, it has to be the same instance as the one
 	 *            used to start scan.
 	 */
-	@SuppressWarnings("unused")
 	public abstract void flushPendingScanResults(@NonNull ScanCallback callback);
 
 	/* package */ static class ScanCallbackWrapper {

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplJB.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplJB.java
@@ -22,7 +22,6 @@
 
 package no.nordicsemi.android.support.v18.scanner;
 
-import android.Manifest;
 import android.app.PendingIntent;
 import android.bluetooth.BluetoothAdapter;
 import android.content.Context;
@@ -31,13 +30,12 @@ import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.SystemClock;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.RequiresPermission;
 
 
 @SuppressWarnings("deprecation")
@@ -57,7 +55,6 @@ import androidx.annotation.RequiresPermission;
 
 	private final Runnable powerSaveSleepTask = new Runnable() {
 		@Override
-		@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 		public void run() {
 			final BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
 			if (adapter != null && powerSaveRestInterval > 0 && powerSaveScanInterval > 0) {
@@ -69,7 +66,6 @@ import androidx.annotation.RequiresPermission;
 
 	private final Runnable powerSaveScanTask = new Runnable() {
 		@Override
-		@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 		public void run() {
 			final BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
 			if (adapter != null && powerSaveRestInterval > 0 && powerSaveScanInterval > 0) {
@@ -82,7 +78,6 @@ import androidx.annotation.RequiresPermission;
 	/* package */ BluetoothLeScannerImplJB() {}
 
 	@Override
-	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 	/* package */ void startScanInternal(@NonNull final List<ScanFilter> filters,
 										 @NonNull final ScanSettings settings,
 										 @NonNull final ScanCallback callback,
@@ -117,7 +112,6 @@ import androidx.annotation.RequiresPermission;
 	}
 
 	@Override
-	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 	/* package */ void stopScanInternal(@NonNull final ScanCallback callback) {
 		final BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
 
@@ -149,7 +143,6 @@ import androidx.annotation.RequiresPermission;
 	}
 
 	@Override
-	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 	/* package */ void startScanInternal(@NonNull final List<ScanFilter> filters,
 										 @NonNull final ScanSettings settings,
 										 @NonNull final Context context,
@@ -165,7 +158,6 @@ import androidx.annotation.RequiresPermission;
 	}
 
 	@Override
-	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 	/* package */ void stopScanInternal(@NonNull final Context context,
 										@NonNull final PendingIntent callbackIntent,
 										final int requestCode) {
@@ -177,7 +169,6 @@ import androidx.annotation.RequiresPermission;
 	}
 
 	@Override
-	@RequiresPermission(Manifest.permission.BLUETOOTH)
 	public void flushPendingScanResults(@NonNull final ScanCallback callback) {
 		//noinspection ConstantConditions
 		if (callback == null) {

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplLollipop.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplLollipop.java
@@ -107,11 +107,11 @@ import androidx.annotation.RequiresPermission;
 
 	@Override
 	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
-		/* package */ void startScanInternal(@NonNull final List<ScanFilter> filters,
-											 @NonNull final ScanSettings settings,
-											 @NonNull final Context context,
-											 @NonNull final PendingIntent callbackIntent,
-											 final int requestCode) {
+	/* package */ void startScanInternal(@NonNull final List<ScanFilter> filters,
+										 @NonNull final ScanSettings settings,
+										 @NonNull final Context context,
+										 @NonNull final PendingIntent callbackIntent,
+										 final int requestCode) {
 		final BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
 		final BluetoothLeScanner scanner = adapter.getBluetoothLeScanner();
 		if (scanner == null)
@@ -128,9 +128,9 @@ import androidx.annotation.RequiresPermission;
 
 	@Override
 	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
-		/* package */ void stopScanInternal(@NonNull final Context context,
-											@NonNull final PendingIntent callbackIntent,
-											final int requestCode) {
+	/* package */ void stopScanInternal(@NonNull final Context context,
+										@NonNull final PendingIntent callbackIntent,
+										final int requestCode) {
 		final Intent service = new Intent(context, ScannerService.class);
 		service.putExtra(ScannerService.EXTRA_PENDING_INTENT, callbackIntent);
 		service.putExtra(ScannerService.EXTRA_REQUEST_CODE, requestCode);

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplLollipop.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplLollipop.java
@@ -22,7 +22,6 @@
 
 package no.nordicsemi.android.support.v18.scanner;
 
-import android.Manifest;
 import android.annotation.TargetApi;
 import android.app.PendingIntent;
 import android.bluetooth.BluetoothAdapter;
@@ -33,11 +32,10 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.SystemClock;
 
+import androidx.annotation.NonNull;
+
 import java.util.ArrayList;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.RequiresPermission;
 
 @SuppressWarnings({"deprecation", "WeakerAccess"})
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
@@ -52,7 +50,6 @@ import androidx.annotation.RequiresPermission;
 	/* package */ BluetoothLeScannerImplLollipop() {}
 
 	@Override
-	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 	/* package */ void startScanInternal(@NonNull final List<ScanFilter> filters,
 										 @NonNull final ScanSettings settings,
 										 @NonNull final ScanCallback callback,
@@ -86,7 +83,6 @@ import androidx.annotation.RequiresPermission;
 	}
 
 	@Override
-	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 	/* package */ void stopScanInternal(@NonNull final ScanCallback callback) {
 		ScanCallbackWrapperLollipop wrapper;
 		synchronized (wrappers) {
@@ -106,7 +102,6 @@ import androidx.annotation.RequiresPermission;
 	}
 
 	@Override
-	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 	/* package */ void startScanInternal(@NonNull final List<ScanFilter> filters,
 										 @NonNull final ScanSettings settings,
 										 @NonNull final Context context,
@@ -127,7 +122,6 @@ import androidx.annotation.RequiresPermission;
 	}
 
 	@Override
-	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 	/* package */ void stopScanInternal(@NonNull final Context context,
 										@NonNull final PendingIntent callbackIntent,
 										final int requestCode) {
@@ -139,7 +133,6 @@ import androidx.annotation.RequiresPermission;
 	}
 
 	@Override
-	@RequiresPermission(Manifest.permission.BLUETOOTH)
 	public void flushPendingScanResults(@NonNull final ScanCallback callback) {
 		final BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
 		//noinspection ConstantConditions

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplOreo.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplOreo.java
@@ -168,8 +168,11 @@ import androidx.annotation.RequiresPermission;
 		intent.putExtra(PendingIntentReceiver.EXTRA_MATCH_MODE, settings.getMatchMode());
 		intent.putExtra(PendingIntentReceiver.EXTRA_NUM_OF_MATCHES, settings.getNumOfMatches());
 
-		return PendingIntent.getBroadcast(context, requestCode, intent,
-				PendingIntent.FLAG_MUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
+		int flags = PendingIntent.FLAG_UPDATE_CURRENT;
+		// Mutable flag has to be set explicitly on Android 12+. Before PendingIntent was mutable by default.
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+			flags |= PendingIntent.FLAG_MUTABLE;
+		return PendingIntent.getBroadcast(context, requestCode, intent, flags);
 	}
 
 	/**
@@ -187,8 +190,12 @@ import androidx.annotation.RequiresPermission;
 		final Intent intent = new Intent(context, PendingIntentReceiver.class);
 		intent.setAction(PendingIntentReceiver.ACTION);
 
-		return PendingIntent.getBroadcast(context, requestCode, intent,
-				PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
+		int flags = PendingIntent.FLAG_UPDATE_CURRENT;
+		// Immutable flag has to be set explicitly on Android 12+, but can be set from Android 6.
+		// Stopping scanning does not require the PendingIntent to be mutable.
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+			flags |= PendingIntent.FLAG_IMMUTABLE;
+		return PendingIntent.getBroadcast(context, requestCode, intent, flags);
 	}
 
 	@NonNull

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplOreo.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplOreo.java
@@ -168,7 +168,8 @@ import androidx.annotation.RequiresPermission;
 		intent.putExtra(PendingIntentReceiver.EXTRA_MATCH_MODE, settings.getMatchMode());
 		intent.putExtra(PendingIntentReceiver.EXTRA_NUM_OF_MATCHES, settings.getNumOfMatches());
 
-		return PendingIntent.getBroadcast(context, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+		return PendingIntent.getBroadcast(context, requestCode, intent,
+				PendingIntent.FLAG_MUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
 	}
 
 	/**
@@ -186,7 +187,8 @@ import androidx.annotation.RequiresPermission;
 		final Intent intent = new Intent(context, PendingIntentReceiver.class);
 		intent.setAction(PendingIntentReceiver.ACTION);
 
-		return PendingIntent.getBroadcast(context, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+		return PendingIntent.getBroadcast(context, requestCode, intent,
+				PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
 	}
 
 	@NonNull

--- a/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplOreo.java
+++ b/scanner/src/main/java/no/nordicsemi/android/support/v18/scanner/BluetoothLeScannerImplOreo.java
@@ -22,7 +22,6 @@
 
 package no.nordicsemi.android.support.v18.scanner;
 
-import android.Manifest;
 import android.annotation.TargetApi;
 import android.app.PendingIntent;
 import android.bluetooth.BluetoothAdapter;
@@ -32,14 +31,13 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.Handler;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.RequiresPermission;
 
 @TargetApi(Build.VERSION_CODES.O)
 /* package */ class BluetoothLeScannerImplOreo extends BluetoothLeScannerImplMarshmallow {
@@ -83,7 +81,6 @@ import androidx.annotation.RequiresPermission;
 	}
 
 	@Override
-	@RequiresPermission(allOf = {Manifest.permission.BLUETOOTH_ADMIN, Manifest.permission.BLUETOOTH})
 	/* package */ void startScanInternal(@Nullable final List<ScanFilter> filters,
 										 @Nullable final ScanSettings settings,
 										 @NonNull  final Context context,
@@ -113,7 +110,6 @@ import androidx.annotation.RequiresPermission;
 		scanner.startScan(nativeFilters, nativeSettings, pendingIntent);
 	}
 
-	@RequiresPermission(Manifest.permission.BLUETOOTH_ADMIN)
 	/* package */ void stopScanInternal(@NonNull final Context context,
 										@NonNull final PendingIntent callbackIntent,
 										final int requestCode) {


### PR DESCRIPTION
This PR raises the `targetSdkVersion` to 31 and fixes issues caused by that:
 * Adds `PendingIntent.MUTABLE` flag to `PendingIntent`. This is required for scanning to work, otherwise the results cannot be delivered. (#106)
 * Sets `maxSdkVersion` to 30 for [BLUETOOTH](https://developer.android.com/reference/android/Manifest.permission#BLUETOOTH) and [BLUETOOT_ADMIN](https://developer.android.com/reference/android/Manifest.permission#BLUETOOTH_ADMIN) permissions.
 * Adds new [BLUETOOT_SCAN](https://developer.android.com/reference/android/Manifest.permission#BLUETOOTH_SCAN) permission ([more](https://developer.android.com/guide/topics/connectivity/bluetooth/permissions)).
 * Removes [ACCESS_FINE_LOCATION](https://developer.android.com/reference/android/Manifest.permission#ACCESS_FINE_LOCATION) as no longer required from Android 12. If your app depends on this permission, make sure you add it in your Android Manifest file.
 * Fixes comments
 * Removes `@RequiredPermission` annotation from `startScan` and `stopScan` methods, as the required permission now depends on the Android version. Native API fixed this issue by adding new annotations, but they are hidden and lint shows errors.