### PR TITLE
Make AndroidManifest permissions more specific by platform

### DIFF
--- a/scanner/src/main/AndroidManifest.xml
+++ b/scanner/src/main/AndroidManifest.xml
@@ -19,15 +19,16 @@
 	       declare this permission with this flag set to "neverForLocation".
 	-->
 	<uses-permission
-		android:name="android.permission.BLUETOOTH_SCAN" />
+		android:name="android.permission.BLUETOOTH_SCAN"
+		tools:targetApi="s" />
 
-	<!--
-	 Location permission has been removed from here, as it may not be required for
-	 Android 12 onwards. It is required on Android 6-11 when scanning for Bluetooth LE devices.
+	<!-- Coarse and fine location, mandatory since Android 6.0 to scan for Bluetooth Low Energy
+	peripherals, not needed starting from Android 12.0. -->
 
-	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
-	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-	-->
+	<uses-permission-sdk-23 android:maxSdkVersion="30"
+        android:name="android.permission.ACCESS_COARSE_LOCATION" />
+	<uses-permission-sdk-23 android:maxSdkVersion="30"
+        android:name="android.permission.ACCESS_FINE_LOCATION" />
 
 	<application>
 		<!--


### PR DESCRIPTION
Some permissions were added on a specific Android API, and were also removed on a different one. This PR intents to delimit the scope of those dangerous permissions. With these changes, the library will cover lower API permission requirements without the need to make any additional change. The only pending customization would be the one related to `usesPermissionFlag` and location, which is already well documented in the manifest file.